### PR TITLE
Override f0_floor and f0_ceil according to the scores of PJS corpus.

### DIFF
--- a/egs/pjs/00-svs-world/run.sh
+++ b/egs/pjs/00-svs-world/run.sh
@@ -82,8 +82,10 @@ if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
 
     for s in ${datasets[@]};
     do
+	# PJS corpus:
+	#Max frequency: 523.2511306011974, Min frequency: 92.4986056779085
       nnsvs-prepare-features utt_list=data/list/$s.list out_dir=$dump_org_dir/$s/  \
-        question_path=$question_path
+        question_path=$question_path acoustic.f0_floor=80 acoustic.f0_ceil=580
     done
 
     # Compute normalization stats for each input/output


### PR DESCRIPTION
The default settings f0_floor and f0_ceil in nnsvs/bin/conf/prepare_features/config.yaml are based on "Tohoku Kiritan" singing database, and may no be adequate for male vocalists.

From musicxml files of PJS corpus, the frequencies of notes range between 92 and 523 Hz, so I suggest to overwrite f0_floor and f0_ceil settings according to the scores with safety margins of 10%.
