### PR TITLE
Neural Source Filter waveform models (NSF) support

### DIFF
--- a/egs/nit-song070/01-svs-nsf/README.md
+++ b/egs/nit-song070/01-svs-nsf/README.md
@@ -1,0 +1,9 @@
+# 01-svs-nsf
+
+A recipe to build a statistical parametric singing voice synthesis system. The system consists of three trainable networks:
+
+1. Time-lag model
+2. Duration model
+3. Acoustic model
+
+The recipe structure is almost the same as [kiritan_singing/00-svs-world](../../kiritan_singing/00-svs-world). Please check the README of kiritan database for more details.

--- a/egs/nit-song070/01-svs-nsf/bin/conf/prepare_nsf_data/config.yaml
+++ b/egs/nit-song070/01-svs-nsf/bin/conf/prepare_nsf_data/config.yaml
@@ -1,0 +1,25 @@
+# coding: utf-8
+defaults:
+  - hydra/job_logging: colorlog
+  - hydra/hydra_logging: colorlog
+
+verbose: 100
+
+in_dir: 
+out_dir: 
+  
+# question path used for timelag, duration and acoustic models
+question_path: conf/jp_qst001_nnsvs.hed
+label_dir: data/acoustic/label_phone_align
+  
+# acoustic parameters
+sample_rate: 16000
+stream_sizes: [180, 3, 1, 3]
+has_dynamic_features: [true, true, false, true]
+# windows to compute delta and delta-delta features. Set 1 to disable
+num_windows: 3
+# Use relative f0 modeling.
+relative_f0: true
+
+# if test_set is set to true, prepare_nsf_data creates acoustic features only(does not create wav files.)
+test_set: false

--- a/egs/nit-song070/01-svs-nsf/bin/conf/synthesis_nsf/config.yaml
+++ b/egs/nit-song070/01-svs-nsf/bin/conf/synthesis_nsf/config.yaml
@@ -1,0 +1,110 @@
+# coding: utf-8
+defaults:
+  - hydra/job_logging: colorlog
+  - hydra/hydra_logging: colorlog
+verbose: 100
+
+nsf_root_dir:
+nsf_type: hn-sinc-nsf
+
+# This setting is for NNSVS
+# The setting for NSF is below
+device: cuda # or cpu
+
+# Only the combination of utt_list and in_dir input is supported
+utt_list:
+in_dir:
+out_dir:
+  
+sample_rate: 16000
+frame_period: 5
+question_path: path/to/qst.hed
+log_f0_conditioning: true
+
+# Use ground truth duration or not
+# if true, time-lag and duration models will not be used.
+ground_truth_duration: false
+
+timelag:
+  question_path:
+  checkpoint:
+  in_scaler_path:
+  out_scaler_path:
+  model_yaml:
+  stream_sizes: [1]
+  has_dynamic_features: [false]
+
+  allowed_range: [-20, 20] # in frames
+  allowed_range_rest: [-40, 40]
+
+duration:
+  question_path:
+  checkpoint:
+  in_scaler_path:
+  out_scaler_path:
+  model_yaml:
+  stream_sizes: [1]
+  has_dynamic_features: [false]
+
+acoustic:
+  question_path:
+  checkpoint:
+  in_scaler_path:
+  out_scaler_path:
+  model_yaml:
+  subphone_features: coarse_coding
+  # (mgc, lf0, vuv, bap)
+  stream_sizes: [180, 3, 1, 3]
+  has_dynamic_features: [true, true, false, true]
+  num_windows: 3
+  relative_f0: true
+  post_filter: true
+
+nsf:
+  args:
+    # NSF default settings except inference
+    batch_size: 1
+    epochs: 50
+    no_best_epochs: 5
+    lr: 0.0001
+    no_cuda: false
+    seed: 1
+    eval_mode_for_validation: false
+    model_forward_with_target: false
+    shuffle: true
+    num_workers: 0
+    save_model_dir: "./"
+    not_save_each_epoch: false
+    save_epoch_name: "epoch"
+    save_trained_name: "trained_network"
+    save_model_ext: ".pt"
+    trained_model:
+    inference: true
+    # Caution. output directory setting of NSF will be overwritten by NNSVS,
+    # output_dir will be never used.
+    output_dir: "./output"
+    optimizer: Adam
+    verbose: 1
+  model:
+    # Dimensions of input features
+    # input_dims = [dimension_of_feature_1, dimension_of_feature_2, ...]
+    input_dims: [60, 1, 1]
+    # File name extension for input features
+    # input_exts = [name_extention_of_feature_1, ...]
+    # ".f0" must be the last
+    input_exts: ['.mgc', '.bap', '.f0']
+    # Temporal resolution for input features
+    # input_reso = [reso_feature_1, reso_feature_2, ...]
+    #  for waveform modeling, temporal resolution of input acoustic features
+    #  may be = waveform_sampling_rate * frame_shift_of_acoustic_features(for example, 80 = 16000 Hz * 5 ms)
+    input_reso: [80, 80, 80]
+    # Whether input features should be z-normalized
+    # input_norm = [normalize_feature_1, normalize_feature_2]
+    input_norm: [True, True, True]
+    # Similar configurations for output features
+    output_dims: [1]
+    output_exts: ['.wav']
+    output_reso: [1]
+    output_norm: [False]
+    # Waveform sampling rate
+    wav_samp_rate: 16000

--- a/egs/nit-song070/01-svs-nsf/bin/conf/synthesis_nsf/config.yaml
+++ b/egs/nit-song070/01-svs-nsf/bin/conf/synthesis_nsf/config.yaml
@@ -71,18 +71,18 @@ nsf:
     seed: 1
     eval_mode_for_validation: false
     model_forward_with_target: false
+    model_forward_with_file_name: false
     shuffle: true
     num_workers: 0
+    multi_gpu_data_parallel: false
     save_model_dir: "./"
     not_save_each_epoch: false
     save_epoch_name: "epoch"
     save_trained_name: "trained_network"
     save_model_ext: ".pt"
     trained_model:
+    ignore_training_history_in_trained_model: false
     inference: true
-    # Caution. output directory setting of NSF will be overwritten by NNSVS,
-    # output_dir will be never used.
-    output_dir: "./output"
     optimizer: Adam
     verbose: 1
   model:

--- a/egs/nit-song070/01-svs-nsf/bin/conf/train_nsf/config.yaml
+++ b/egs/nit-song070/01-svs-nsf/bin/conf/train_nsf/config.yaml
@@ -29,18 +29,18 @@ nsf:
     seed: 1
     eval_mode_for_validation: false
     model_forward_with_target: false
+    model_forward_with_file_name: false
     shuffle: true
     num_workers: 0
+    multi_gpu_data_parallel: false
     save_model_dir: "./"
     not_save_each_epoch: false
     save_epoch_name: "epoch"
     save_trained_name: "trained_network"
     save_model_ext: ".pt"
     trained_model:
+    ignore_training_history_in_trained_model: false
     inference: false
-    # Caution. output directory setting of NSF will be overwritten by NNSVS,
-    # output_dir will be never used.
-    output_dir: "./output"
     optimizer: Adam
     verbose: 1
   model:
@@ -84,4 +84,4 @@ nsf:
     # test_input_dirs = [path_of_feature_1, path_of_feature_2, ..., ]
     test_input_dirs: ["nsf/test_input_dirs", "nsf/test_input_dirs", "nsf/test_input_dirs"]
     # test_output_dirs is used to store synthesized waves at inference.
-    test_output_dirs: []
+    test_output_dirs: 

--- a/egs/nit-song070/01-svs-nsf/bin/conf/train_nsf/config.yaml
+++ b/egs/nit-song070/01-svs-nsf/bin/conf/train_nsf/config.yaml
@@ -1,0 +1,87 @@
+# coding: utf-8
+defaults:
+  - hydra/job_logging: colorlog
+  - hydra/hydra_logging: colorlog
+verbose: 100
+
+nsf_root_dir:
+nsf_type: hn-sinc-nsf
+  
+data:
+  #training set
+  train_no_dev:
+    list_path: data/list/train_no_dev.list
+  #development set
+  dev:
+    list_path: data/list/dev.list
+  #evaluation set
+  eval:
+    list_path: data/list/eval.list
+    
+nsf:
+  args:
+    # NSF default settings
+    batch_size: 1
+    epochs: 50
+    no_best_epochs: 5
+    lr: 0.0001
+    no_cuda: false
+    seed: 1
+    eval_mode_for_validation: false
+    model_forward_with_target: false
+    shuffle: true
+    num_workers: 0
+    save_model_dir: "./"
+    not_save_each_epoch: false
+    save_epoch_name: "epoch"
+    save_trained_name: "trained_network"
+    save_model_ext: ".pt"
+    trained_model:
+    inference: false
+    # Caution. output directory setting of NSF will be overwritten by NNSVS,
+    # output_dir will be never used.
+    output_dir: "./output"
+    optimizer: Adam
+    verbose: 1
+  model:
+    # Directories for input features
+    # input_dirs = [path_of_feature_1, path_of_feature_2, ..., ]
+    input_dirs: ["nsf/input_dirs" , "nsf/input_dirs", "nsf/input_dirs"]
+    # Dimensions of input features
+    # input_dims = [dimension_of_feature_1, dimension_of_feature_2, ...]
+    input_dims: [60, 1, 1]
+    # File name extension for input features
+    # input_exts = [name_extention_of_feature_1, ...]
+    # ".f0" must be the last
+    input_exts: ['.mgc', '.bap', '.f0']
+    # Temporal resolution for input features
+    # input_reso = [reso_feature_1, reso_feature_2, ...]
+    #  for waveform modeling, temporal resolution of input acoustic features
+    #  may be = waveform_sampling_rate * frame_shift_of_acoustic_features(for example, 80 = 16000 Hz * 5 ms)
+    input_reso: [80, 80, 80]
+    # Whether input features should be z-normalized
+    # input_norm = [normalize_feature_1, normalize_feature_2]
+    input_norm: [True, True, True]
+    # Similar configurations for output features
+    output_dirs: ["nsf/output_dirs"]
+    output_dims: [1]
+    output_exts: ['.wav']
+    output_reso: [1]
+    output_norm: [False]
+    # Waveform sampling rate
+    wav_samp_rate: 16000
+    # Truncating input sequences so that the maximum length = truncate_seq
+    #  When truncate_seq is larger, more GPU mem required
+    # If you don't want truncating, please truncate_seq = None
+    # sample_rate * sec (for example, 48000 = 16000 Hz * 3 s)
+    truncate_seq: 48000
+    # Minimum sequence length
+    #  If sequence length < minimum_len, this sequence is not used for training
+    #  minimum_len can be None
+    # resolution * minimum frames(for rexample 4000 = 80(sample/frame) * 50(frame)
+    minimum_len: 4000
+    # Directories for test input features
+    # test_input_dirs = [path_of_feature_1, path_of_feature_2, ..., ]
+    test_input_dirs: ["nsf/test_input_dirs", "nsf/test_input_dirs", "nsf/test_input_dirs"]
+    # test_output_dirs is used to store synthesized waves at inference.
+    test_output_dirs: []

--- a/egs/nit-song070/01-svs-nsf/bin/prepare_nsf_data.py
+++ b/egs/nit-song070/01-svs-nsf/bin/prepare_nsf_data.py
@@ -103,13 +103,15 @@ def my_app(config : DictConfig) -> None:
 
         if exists(feats_out_dir) != True:
             os.makedirs(feats_out_dir)
-                    
+
+        # NSF binary data format is required to be read by numpy.fromfile.
+        # "npy" format may not be adequate.
         with open(join(feats_out_dir, utt_id + ".f0"), "wb") as f:
-            np.save(f, f0.astype(np.float32))
+            f0.astype(np.float32).tofile(f)
         with open(join(feats_out_dir, utt_id + ".mgc"), "wb") as f:
-            np.save(f, mgc.astype(np.float32))
+            mgc.astype(np.float32).tofile(f)
         with open(join(feats_out_dir, utt_id + ".bap"), "wb") as f:
-            np.save(f, bap.astype(np.float32))
+            bap.astype(np.float32).tofile(f)
     
     if test_set != True:
         wave_files = sorted(glob(join(in_dir, "*-wave.npy")))

--- a/egs/nit-song070/01-svs-nsf/bin/prepare_nsf_data.py
+++ b/egs/nit-song070/01-svs-nsf/bin/prepare_nsf_data.py
@@ -1,0 +1,134 @@
+# coding: utf-8
+import hydra
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig
+
+import sys
+from glob import glob
+import os
+from os.path import join, basename, splitext, exists
+import numpy as np
+import librosa
+import soundfile as sf
+import torch
+
+from tqdm import tqdm
+
+from nnmnkwii.io import hts
+from nnmnkwii.frontend import merlin as fe
+from nnmnkwii.preprocessing.f0 import interp1d
+
+from nnsvs.multistream import get_static_features, get_static_stream_sizes, split_streams
+from nnsvs.logger import getLogger
+logger = None
+
+def _midi_to_hz(x, idx, log_f0=False):
+    z = np.zeros(len(x))
+    indices = x[:, idx] > 0
+    z[indices] = librosa.midi_to_hz(x[indices, idx])
+    if log_f0:
+        z[indices] = np.log(z[indices])
+    return z
+
+@hydra.main(config_path="conf/prepare_nsf_data/config.yaml")
+def my_app(config : DictConfig) -> None:
+    global logger
+    logger = getLogger(config.verbose)
+    logger.info(config.pretty())
+
+    in_dir = to_absolute_path(config.in_dir)
+    out_dir = to_absolute_path(config.out_dir)
+
+    label_dir = to_absolute_path(config.label_dir)
+    question_path = to_absolute_path(config.question_path)
+
+    relative_f0=config.relative_f0
+    stream_sizes=config.stream_sizes
+    has_dynamic_features=config.has_dynamic_features
+    num_windows=config.num_windows
+    sample_rate=config.sample_rate
+    test_set=config.test_set
+
+    binary_dict, continuous_dict = hts.load_question_set(question_path, append_hat_for_LL=False)
+    pitch_idx=len(binary_dict)+1
+
+    feats_files = sorted(glob(join(in_dir, "*-feats.npy")))
+    logger.info(f"Process {len(feats_files)} feature files for NSF.")
+    for idx in tqdm(range(len(feats_files))):
+        feat_file=feats_files[idx]
+        utt_id = splitext(basename(feat_file))[0].replace("-feats", "")
+        label_path= join(label_dir, utt_id + ".lab")
+        labels = hts.load(label_path)
+
+        acoustic_features = np.load(feat_file)
+
+        if np.any(has_dynamic_features):
+            # get_static_features requires torch.Tensor, so it is necessary to wrap acoustic_features
+            _acoustic_features = torch.from_numpy(acoustic_features.astype(np.float32)).unsqueeze(0)
+            acoustic_features = get_static_features(_acoustic_features, num_windows, stream_sizes, has_dynamic_features).squeeze(0).cpu().data.numpy()
+            static_stream_sizes = get_static_stream_sizes(
+                stream_sizes, has_dynamic_features, num_windows)
+        else:
+            static_stream_sizes = stream_sizes
+        
+        mgc, target_f0, vuv, bap = split_streams(acoustic_features, static_stream_sizes)
+
+        if relative_f0:
+            diff_lf0 = target_f0
+            # need to extract pitch sequence from the musical score
+            linguistic_features = fe.linguistic_features(labels, binary_dict, continuous_dict,
+                                                         add_frame_features=True,
+                                                         subphone_features="coarse_coding")
+            f0_score = _midi_to_hz(linguistic_features, pitch_idx, False)[:, None]
+
+            if len(f0_score) > len(diff_lf0):
+                print("Warning! likely to have mistakes in alignment in {}".format(label_path))
+                print(f0_score.shape, diff_lf0.shape)
+
+            f0_score = f0_score[:len(diff_lf0)]        
+            lf0_score = f0_score.copy()
+            nonzero_indices = np.nonzero(lf0_score)
+            lf0_score[nonzero_indices] = np.log(f0_score[nonzero_indices])
+            lf0_score = interp1d(lf0_score, kind="slinear")
+            f0 = diff_lf0 + lf0_score
+            f0[vuv < 0.5] = 0
+            f0[np.nonzero(f0)] = np.exp(f0[np.nonzero(f0)])
+        else:
+            f0 = target_f0
+                
+        if test_set:
+            feats_out_dir = join(out_dir , "test_input_dirs")
+        else:
+            feats_out_dir = join(out_dir , "input_dirs")
+
+        if exists(feats_out_dir) != True:
+            os.makedirs(feats_out_dir)
+                    
+        with open(join(feats_out_dir, utt_id + ".f0"), "wb") as f:
+            np.save(f, f0.astype(np.float32))
+        with open(join(feats_out_dir, utt_id + ".mgc"), "wb") as f:
+            np.save(f, mgc.astype(np.float32))
+        with open(join(feats_out_dir, utt_id + ".bap"), "wb") as f:
+            np.save(f, bap.astype(np.float32))
+    
+    if test_set != True:
+        wave_files = sorted(glob(join(in_dir, "*-wave.npy")))
+        logger.info(f"Process {len(wave_files)} wave files for NSF.")
+        for idx in tqdm(range(len(wave_files))):
+            wave_file=wave_files[idx]
+            utt_id = splitext(basename(wave_file))[0].replace("-wave", "")
+                        
+            data = np.load(wave_file)
+            wave_out_dir = join(out_dir, "output_dirs")
+            if exists(wave_out_dir) != True:
+                os.makedirs(wave_out_dir)
+        
+            wav_output_path = join(wave_out_dir, utt_id + ".wav")
+            sf.write(wav_output_path, data, sample_rate)
+
+def entry():
+    my_app()
+
+if __name__ == "__main__":
+    my_app()
+                            

--- a/egs/nit-song070/01-svs-nsf/bin/synthesis_nsf.py
+++ b/egs/nit-song070/01-svs-nsf/bin/synthesis_nsf.py
@@ -1,0 +1,312 @@
+# coding: utf-8
+import hydra
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig, OmegaConf
+
+import numpy as np
+import joblib
+import torch
+import sys
+import os
+from os.path import exists, join, splitext
+
+import pysptk
+import librosa
+
+from nnmnkwii.io import hts
+from nnmnkwii.frontend import merlin as fe
+from nnmnkwii.postfilters import merlin_post_filter
+from nnmnkwii.preprocessing.f0 import interp1d
+from nnsvs.multistream import multi_stream_mlpg, get_static_stream_sizes, split_streams
+
+from nnsvs.gen import (
+    predict_timelag, predict_duration, predict_acoustic, postprocess_duration)
+
+from nnsvs.logger import getLogger
+logger = None
+
+# This function is originated from nnsvs/gen.py
+def get_windows(num_window=1):
+    windows = [(0, 0, np.array([1.0]))]
+    if num_window >= 2:
+        windows.append((1, 1, np.array([-0.5, 0.0, 0.5])))
+    if num_window >= 3:
+        windows.append((1, 1, np.array([1.0, -2.0, 1.0])))
+
+    if num_window >= 4:
+        raise ValueError(f"Not supported num windows: {num_window}")
+
+    return windows
+
+# This function is originated from nsvs/gen.py
+def _midi_to_hz(x, idx, log_f0=False):
+    z = np.zeros(len(x))
+    indices = x[:, idx] > 0
+    z[indices] = librosa.midi_to_hz(x[indices, idx])
+    if log_f0:
+        z[indices] = np.log(z[indices])
+    return z
+
+# This function is derived from gen_wavform in nnsvs/gen.py
+def get_static_acoustic_features(labels, acoustic_features, acoustic_out_scaler,
+                                 binary_dict, continuous_dict, stream_sizes, has_dynamic_features,
+                                 subphone_features="coarse_coding", log_f0_conditioning=True, pitch_idx=None,
+                                 num_windows=3, post_filter=True, sample_rate=48000, frame_period=5,
+                                 relative_f0=True):
+    windows = get_windows(num_windows)
+
+    # Apply MLPG if necessary
+    if np.any(has_dynamic_features):
+        acoustic_features = multi_stream_mlpg(
+            acoustic_features, acoustic_out_scaler.var_, windows, stream_sizes,
+            has_dynamic_features)
+        static_stream_sizes = get_static_stream_sizes(
+            stream_sizes, has_dynamic_features, len(windows))
+    else:
+        static_stream_sizes = stream_sizes
+
+    # Split multi-stream features
+    mgc, target_f0, vuv, bap = split_streams(acoustic_features, static_stream_sizes)
+
+    alpha = pysptk.util.mcepalpha(sample_rate)
+
+    if post_filter:
+        mgc = merlin_post_filter(mgc, alpha)
+
+    ### F0 ###
+    if relative_f0:
+        diff_lf0 = target_f0
+        # need to extract pitch sequence from the musical score
+        linguistic_features = fe.linguistic_features(labels,
+                                                    binary_dict, continuous_dict,
+                                                    add_frame_features=True,
+                                                    subphone_features=subphone_features)
+        f0_score = _midi_to_hz(linguistic_features, pitch_idx, False)[:, None]
+        lf0_score = f0_score.copy()
+        nonzero_indices = np.nonzero(lf0_score)
+        lf0_score[nonzero_indices] = np.log(f0_score[nonzero_indices])
+        lf0_score = interp1d(lf0_score, kind="slinear")
+
+        f0 = diff_lf0 + lf0_score
+        f0[vuv < 0.5] = 0
+        f0[np.nonzero(f0)] = np.exp(f0[np.nonzero(f0)])
+    else:
+        f0 = target_f0
+    return mgc, f0, bap
+    
+def dump_acoustic_features(config, device, label_path, question_path,
+                           timelag_model, timelag_in_scaler, timelag_out_scaler,
+                           duration_model, duration_in_scaler, duration_out_scaler,
+                           acoustic_model, acoustic_in_scaler, acoustic_out_scaler,
+                           out_dir, utt_id):
+    # load labels and question
+    labels = hts.load(label_path).round_()
+    binary_dict, continuous_dict = hts.load_question_set(
+        question_path, append_hat_for_LL=False)
+
+    # pitch indices in the input features
+    # TODO: configuarable
+    pitch_idx = len(binary_dict) + 1
+    pitch_indices = np.arange(len(binary_dict), len(binary_dict)+3)
+
+    log_f0_conditioning = config.log_f0_conditioning
+
+    if config.ground_truth_duration:
+        # Use provided alignment
+        duration_modified_labels = labels
+    else:
+        # Time-lag
+        lag = predict_timelag(device, labels, timelag_model, timelag_in_scaler,
+            timelag_out_scaler, binary_dict, continuous_dict, pitch_indices,
+            log_f0_conditioning, config.timelag.allowed_range)
+
+        # Timelag predictions
+        durations = predict_duration(device, labels, duration_model,
+            duration_in_scaler, duration_out_scaler, lag, binary_dict, continuous_dict,
+            pitch_indices, log_f0_conditioning)
+
+        # Normalize phoneme durations
+        duration_modified_labels = postprocess_duration(labels, durations, lag)
+
+    # Predict acoustic features
+    acoustic_features = predict_acoustic(device, duration_modified_labels, acoustic_model,
+        acoustic_in_scaler, acoustic_out_scaler, binary_dict, continuous_dict,
+        config.acoustic.subphone_features, pitch_indices, log_f0_conditioning)
+
+    # Get mgc/f0/bap from acoustic features
+    mgc, f0, bap = get_static_acoustic_features(duration_modified_labels, acoustic_features,
+                                                acoustic_out_scaler, binary_dict,
+                                                continuous_dict, config.acoustic.stream_sizes,
+                                                config.acoustic.has_dynamic_features,
+                                                config.acoustic.subphone_features,
+                                                log_f0_conditioning,
+                                                pitch_idx, config.acoustic.num_windows,
+                                                config.acoustic.post_filter, config.sample_rate,
+                                                config.frame_period,
+                                                config.acoustic.relative_f0)
+
+    # Save mgc/f0/bap
+    with open(join(out_dir, utt_id + ".f0"), "wb") as f:
+        np.save(f, f0.astype(np.float32))
+    with open(join(out_dir, utt_id + ".mgc"), "wb") as f:
+        np.save(f, mgc.astype(np.float32))
+    with open(join(out_dir, utt_id + ".bap"), "wb") as f:
+        np.save(f, bap.astype(np.float32))
+
+def synthesis_nsf(config, utt_list, input_dir, output_dir):
+    # load NSF modules
+    assert config.nsf_root_dir
+    nsf_root_dir = to_absolute_path(config.nsf_root_dir)
+    sys.path.append(nsf_root_dir)
+    import core_scripts.data_io.default_data_io as nii_dset
+    import core_scripts.other_tools.list_tools as nii_list_tool
+    import core_scripts.nn_manager.nn_manager as nii_nn_wrapper
+
+    # load NSF model
+    if config.nsf_type == "hn-sinc-nsf":
+        sys.path.append(to_absolute_path(join(config.nsf_root_dir, "project/hn-sinc-nsf-9")))
+    elif config.nsf_type == "hn-nsf":
+        sys.path.append(to_absolute_path(join(config.nsf_root_dir, "project/hn-nsf")))
+    elif config.nsf_type == "cyc-noise-nsf":
+        sys.path.append(to_absolute_path(join(config.nsf_root_dir, "project/cyc-noise-nsf-4")))
+    else:
+        raise Exception(f"Unknown NSF type: {config.nsf_type}")
+
+    import model as nsf_model
+
+    # Overwrite output_dir setting
+    logger.info(f"NSF setting of config.nsf.args.output_dir is overwritten with {output_dir} by NNSVS.")
+    
+    config.nsf.args.output_dir = to_absolute_path(output_dir)
+    
+    # Initialization
+    torch.manual_seed(config.nsf.args.seed)
+    use_cuda = not config.nsf.args.no_cuda and torch.cuda.is_available()
+    device = torch.device("cuda" if use_cuda else "cpu")
+
+    # Prepare data io    
+    params = {'batch_size':  config.nsf.args.batch_size,
+              'shuffle':  config.nsf.args.shuffle,
+              'num_workers': config.nsf.args.num_workers}
+
+    # fix config.nsf.args.save_model_dir 
+    logger.info(f"NSF setting of config.nsf.args.save_model_dir is converted to absolute path by NNSVS.")
+    config.nsf.args.save_model_dir = to_absolute_path(config.nsf.args.save_model_dir)
+    
+    test_set = nii_dset.NIIDataSetLoader("eval",
+                                         utt_list, 
+                                         [input_dir] * 3,
+                                         config.nsf.model.input_exts, 
+                                         config.nsf.model.input_dims, 
+                                         config.nsf.model.input_reso, 
+                                         config.nsf.model.input_norm, 
+                                         [],
+                                         config.nsf.model.output_exts, 
+                                         config.nsf.model.output_dims, 
+                                         config.nsf.model.output_reso, 
+                                         config.nsf.model.output_norm, 
+                                         config.nsf.args.save_model_dir,
+                                         params = params,
+                                         truncate_seq = None,
+                                         min_seq_len = None,
+                                         save_mean_std = False,
+                                         wav_samp_rate = config.nsf.model.wav_samp_rate)
+
+
+    # Initialize the model and loss function
+    # Originally nsf_mode.Model requires args as Namespace Object, not DictConfig object.
+    # But hydra uses ArgumentParser internally so we can't use nii_arg_parse.f_args_parsed().
+    # Ugly duck typing :(
+    model = nsf_model.Model(test_set.get_in_dim(),
+                            test_set.get_out_dim(), 
+                            config.nsf.args)
+
+    if not config.nsf.args.trained_model:
+        print("config.nsf.args.trained_model is not set, so try to load default trained model")
+        default_trained_model_path = to_absolute_path(join(config.nsf.args.save_model_dir,
+                                                           "{}{}".format(config.nsf.args.save_trained_name,
+                                                                         config.nsf.args.save_model_ext)))
+        if not exists(default_trained_model_path):
+            raise Exception("No trained model found")
+        checkpoint = torch.load(default_trained_model_path)
+    else:
+        checkpoint = torch.load(to_absolute_path(config.nsf.args.trained_model))
+
+    # do inference and output data
+    nii_nn_wrapper.f_inference_wrapper(config.nsf.args, model, device,
+                                       test_set, checkpoint)
+    
+@hydra.main(config_path="conf/synthesis_nsf/config.yaml")
+def my_app(config : DictConfig) -> None:
+    global logger
+    logger = getLogger(config.verbose)
+    logger.info(config.pretty())
+
+    if not torch.cuda.is_available():
+        device = torch.device("cpu")
+    else:
+        device = torch.device(config.device)
+
+    # timelag
+    timelag_config = OmegaConf.load(to_absolute_path(config.timelag.model_yaml))
+    timelag_model = hydra.utils.instantiate(timelag_config.netG).to(device)
+    checkpoint = torch.load(to_absolute_path(config.timelag.checkpoint),
+        map_location=lambda storage, loc: storage)
+    timelag_model.load_state_dict(checkpoint["state_dict"])
+    timelag_in_scaler = joblib.load(to_absolute_path(config.timelag.in_scaler_path))
+    timelag_out_scaler = joblib.load(to_absolute_path(config.timelag.out_scaler_path))
+    timelag_model.eval()
+
+    # duration
+    duration_config = OmegaConf.load(to_absolute_path(config.duration.model_yaml))
+    duration_model = hydra.utils.instantiate(duration_config.netG).to(device)
+    checkpoint = torch.load(to_absolute_path(config.duration.checkpoint),
+        map_location=lambda storage, loc: storage)
+    duration_model.load_state_dict(checkpoint["state_dict"])
+    duration_in_scaler = joblib.load(to_absolute_path(config.duration.in_scaler_path))
+    duration_out_scaler = joblib.load(to_absolute_path(config.duration.out_scaler_path))
+    duration_model.eval()
+
+    # acoustic model
+    acoustic_config = OmegaConf.load(to_absolute_path(config.acoustic.model_yaml))
+    acoustic_model = hydra.utils.instantiate(acoustic_config.netG).to(device)
+    checkpoint = torch.load(to_absolute_path(config.acoustic.checkpoint),
+        map_location=lambda storage, loc: storage)
+    acoustic_model.load_state_dict(checkpoint["state_dict"])
+    acoustic_in_scaler = joblib.load(to_absolute_path(config.acoustic.in_scaler_path))
+    acoustic_out_scaler = joblib.load(to_absolute_path(config.acoustic.out_scaler_path))
+    acoustic_model.eval()
+
+    # Run synthesis for each utt.
+    question_path = to_absolute_path(config.question_path)
+
+    assert config.utt_list
+    in_dir = to_absolute_path(config.in_dir)
+    out_dir = to_absolute_path(config.out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+
+    utt_list = []
+    with open(to_absolute_path(config.utt_list)) as f:
+        lines = f.readlines()
+        for l in lines:
+            if len(l.strip()) > 0:
+                utt_list.append(l.strip())
+                
+    logger.info(f"Processes {len(utt_list)} utterances...")
+    for utt_id in utt_list:
+        label_path = join(in_dir, f"{utt_id}.lab")
+        if not exists(label_path):
+            raise RuntimeError(f"Label file does not exist: {label_path}")
+        dump_acoustic_features(config, device, label_path, question_path,
+                               timelag_model, timelag_in_scaler, timelag_out_scaler,
+                               duration_model, duration_in_scaler, duration_out_scaler,
+                               acoustic_model, acoustic_in_scaler, acoustic_out_scaler,
+                               out_dir, utt_id)
+    synthesis_nsf(config, utt_list, out_dir, out_dir)
+
+def entry():
+    my_app()
+
+if __name__ == "__main__":
+    my_app()
+                            

--- a/egs/nit-song070/01-svs-nsf/bin/train_nsf.py
+++ b/egs/nit-song070/01-svs-nsf/bin/train_nsf.py
@@ -1,0 +1,220 @@
+# coding: utf-8
+import hydra
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig
+
+import os
+from os.path import exists, join, splitext
+import sys
+import torch
+import copy
+
+from nnsvs.logger import getLogger
+logger = None
+
+@hydra.main(config_path="conf/train_nsf/config.yaml")
+def my_app(config : DictConfig) -> None:
+    global logger
+    logger = getLogger(config.verbose)
+    logger.info(config.pretty())
+
+    assert config.nsf_root_dir
+    nsf_root_dir = to_absolute_path(config.nsf_root_dir)
+    sys.path.append(nsf_root_dir)
+    import core_scripts.data_io.default_data_io as nii_dset
+    import core_scripts.other_tools.list_tools as nii_list_tool
+    import core_scripts.op_manager.op_manager as nii_op_wrapper
+    import core_scripts.nn_manager.nn_manager as nii_nn_wrapper
+
+    if config.nsf_type == "hn-sinc-nsf":
+        sys.path.append(to_absolute_path(join(config.nsf_root_dir, "project/hn-sinc-nsf-9")))
+    elif config.nsf_type == "hn-nsf":
+        sys.path.append(to_absolute_path(join(config.nsf_root_dir, "project/hn-nsf")))
+    elif config.nsf_type == "cyc-noise-nsf":
+        sys.path.append(to_absolute_path(join(config.nsf_root_dir, "project/cyc-noise-nsf-4")))
+    else:
+        raise Exception(f"Unknown NSF type: {config.nsf_type}")
+
+    import model as nsf_model
+    
+    # initialization
+    torch.manual_seed(config.nsf.args.seed)
+    use_cuda = not config.nsf.args.no_cuda and torch.cuda.is_available()
+    device = torch.device("cuda" if use_cuda else "cpu")
+
+    # fix config.nsf.args.save_model_dir 
+    logger.info(f"config.nsf.args.save_model_dir is converted to absolute path by NNSVS.")
+    config.nsf.args.save_model_dir = to_absolute_path(config.nsf.args.save_model_dir)
+    
+    if not config.nsf.args.inference:
+        # prepare data io    
+        params = {'batch_size':  config.nsf.args.batch_size,
+                  'shuffle':  config.nsf.args.shuffle,
+                  'num_workers': config.nsf.args.num_workers}
+
+        # Load file list and create data loader
+        train_list_path = to_absolute_path(config.data.train_no_dev.list_path)
+        train_list = nii_list_tool.read_list_from_text(train_list_path)
+
+        input_dirs = [to_absolute_path(x) for x in config.nsf.model.input_dirs]
+        output_dirs = [to_absolute_path(x) for x in config.nsf.model.output_dirs]
+
+        # If we pass config.nsf.model.input_* to NIIDataSet.f_calculate_stats(), 
+        # it will overwrite them because it assumes them as List object, not "ListConfig" 
+        # object(This mismatch results from the adaption of Hydra instead of simple config.py).
+        # To avoid this, deepcopies of input_* are created.
+        # FIXME
+        input_exts = copy.deepcopy(config.nsf.model.input_exts)
+        input_dims = copy.deepcopy(config.nsf.model.input_dims)
+        input_reso = copy.deepcopy(config.nsf.model.input_reso)
+        input_norm = copy.deepcopy(config.nsf.model.input_norm)
+
+        train_set = nii_dset.NIIDataSetLoader("train_no_dev",
+                                              train_list, 
+                                              input_dirs,
+                                              input_exts, 
+                                              input_dims, 
+                                              input_reso, 
+                                              input_norm, 
+                                              output_dirs,
+                                              config.nsf.model.output_exts, 
+                                              config.nsf.model.output_dims, 
+                                              config.nsf.model.output_reso, 
+                                              config.nsf.model.output_norm, 
+                                              config.nsf.args.save_model_dir,
+                                              params = params,
+                                              truncate_seq = config.nsf.model.truncate_seq, 
+                                              min_seq_len = config.nsf.model.minimum_len,
+                                              save_mean_std = True,
+                                              wav_samp_rate = config.nsf.model.wav_samp_rate)
+
+        val_list_path = to_absolute_path(config.data.dev.list_path)
+        val_list = nii_list_tool.read_list_from_text(val_list_path)
+
+        # If we pass config.nsf.model.input_* to NIIDataSet.f_calculate_stats(), 
+        # it will overwrite them because it assumes them as List object, not "ListConfig" 
+        # object(This mismatch results from the adaption of Hydra instead of simple config.py).
+        # To avoid this, deepcopies of input_* are created.
+        # FIXME
+
+        input_exts = copy.deepcopy(config.nsf.model.input_exts)
+        input_dims = copy.deepcopy(config.nsf.model.input_dims)
+        input_reso = copy.deepcopy(config.nsf.model.input_reso)
+        input_norm = copy.deepcopy(config.nsf.model.input_norm)
+
+        val_set = nii_dset.NIIDataSetLoader("dev",
+                                            val_list,
+                                            input_dirs,
+                                            input_exts,
+                                            input_dims,
+                                            input_reso,
+                                            input_norm,
+                                            output_dirs,
+                                            config.nsf.model.output_exts,
+                                            config.nsf.model.output_dims,
+                                            config.nsf.model.output_reso,
+                                            config.nsf.model.output_norm,
+                                            config.nsf.args.save_model_dir,
+                                            params = params,
+                                            truncate_seq= config.nsf.model.truncate_seq, 
+                                            min_seq_len = config.nsf.model.minimum_len,
+                                            save_mean_std = False,
+                                            wav_samp_rate = config.nsf.model.wav_samp_rate)
+        
+        # Initialize the model and loss function
+        # Originally nsf_mode.Model requires args as Namespace Object, not DictConfig object.
+        # But hydra uses ArgumentParser internally so we can't use nii_arg_parse.f_args_parsed().
+        # Ugly duck typing :(
+        model = nsf_model.Model(train_set.get_in_dim(),
+                                train_set.get_out_dim(), 
+                                config.nsf.args, train_set.get_data_mean_std())
+        loss_wrapper = nsf_model.Loss(config.nsf.args)
+
+        # initialize the optimizer
+        optimizer_wrapper = nii_op_wrapper.OptimizerWrapper(model, config.nsf.args)
+
+        # if necessary, resume training
+        if not config.nsf.args.trained_model:
+            checkpoint = None 
+        else:
+            checkpoint = torch.load(to_absolute_path(config.nsf.args.trained_model))
+            
+            # start training
+        logger.info(f"Start {config.nsf_type} training. This may take several days.")
+        nii_nn_wrapper.f_train_wrapper(config.nsf.args, model, 
+                                       loss_wrapper, device,
+                                       optimizer_wrapper,
+                                       train_set, val_set, checkpoint)
+    else:
+        # for inference
+
+        # default, no truncating, no shuffling
+        params = {'batch_size':  config.nsf.args.batch_size,
+                  'shuffle':  False,
+                  'num_workers': config.nsf.args.num_workers}
+        test_list_path = to_absolute_path(config.data.eval.list_path)
+        test_list = nii_list_tool.read_list_from_text(test_list_path)
+
+        # If we pass config.nsf.model.input_* to NIIDataSet.f_calculate_stats(), 
+        # it will overwrite them because it assumes them as List object, not "ListConfig" 
+        # object(This mismatch results from the adaption of Hydra instead of simple config.py).
+        # To avoid this, deepcopies of input_* are created.
+        # FIXME
+        input_exts = copy.deepcopy(config.nsf.model.input_exts)
+        input_dims = copy.deepcopy(config.nsf.model.input_dims)
+        input_reso = copy.deepcopy(config.nsf.model.input_reso)
+        input_norm = copy.deepcopy(config.nsf.model.input_norm)
+
+        test_input_dirs = [to_absolute_path(x) for x in config.nsf.model.test_input_dirs]
+        # Overwrite output_dir setting
+        logger.info(f"NSF setting of config.nsf.args.output_dir is overwritten with {config.nsf.model.test_output_dirs} by NNSVS.")
+        config.nsf.args.output_dir = to_absolute_path(config.nsf.model.test_output_dirs)
+
+        save_model_dir = to_absolute_path(config.nsf.args.save_model_dir)
+
+        test_set = nii_dset.NIIDataSetLoader("eval",
+                                             test_list, 
+                                             test_input_dirs,
+                                             input_exts, 
+                                             input_dims, 
+                                             input_reso, 
+                                             input_norm, 
+                                             [],
+                                             config.nsf.model.output_exts, 
+                                             config.nsf.model.output_dims, 
+                                             config.nsf.model.output_reso, 
+                                             config.nsf.model.output_norm, 
+                                             save_model_dir, 
+                                             params = params,
+                                             truncate_seq = None,
+                                             min_seq_len = None,
+                                             save_mean_std = False,
+                                             wav_samp_rate = config.nsf.model.wav_samp_rate)
+        # Initialize the model
+        # Originally nsf_mode.Model requires args as Namespace Object, not DictConfig object.
+        # But hydra uses ArgumentParser internally so we can't use nii_arg_parse.f_args_parsed().
+        # Ugly duck typing :(
+        model = nsf_model.Model(test_set.get_in_dim(),
+                                test_set.get_out_dim(), 
+                                config.nsf.args)
+
+        if not config.nsf.args.trained_model:
+            print("config.nsf.args.trained_model is not set, so try to load default trained model")
+            default_trained_model_path = to_absolute_path(join(config.nsf.args.save_model_dir,
+                                                               "{}{}".format(config.nsf.args.save_trained_name,
+                                                                             config.nsf.args.save_model_ext)))
+            if not exists(default_trained_model_path):
+                raise Exception("No trained model found")
+            checkpoint = torch.load(default_trained_model_path)
+        else:
+            checkpoint = torch.load(to_absolute_path(config.nsf.args.trained_model))
+        # do inference and output data
+        nii_nn_wrapper.f_inference_wrapper(config.nsf.args, model, device,
+                                           test_set, checkpoint)
+
+def entry():
+    my_app()
+
+if __name__ == "__main__":
+    my_app()
+                            

--- a/egs/nit-song070/01-svs-nsf/bin/train_nsf.py
+++ b/egs/nit-song070/01-svs-nsf/bin/train_nsf.py
@@ -2,7 +2,7 @@
 import hydra
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig
-
+import argparse
 import os
 from os.path import exists, join, splitext
 import sys
@@ -38,19 +38,53 @@ def my_app(config : DictConfig) -> None:
     import model as nsf_model
     
     # initialization
-    torch.manual_seed(config.nsf.args.seed)
-    use_cuda = not config.nsf.args.no_cuda and torch.cuda.is_available()
-    device = torch.device("cuda" if use_cuda else "cpu")
-
-    # fix config.nsf.args.save_model_dir 
-    logger.info(f"config.nsf.args.save_model_dir is converted to absolute path by NNSVS.")
-    config.nsf.args.save_model_dir = to_absolute_path(config.nsf.args.save_model_dir)
+    # All NSF related settings are copied to argparse.Namespace object, because NSF core scripts are written
+    # to work with argparse, not hydra.
+    # Settings of file paths are converted to absolute ones(save_model_dir, trained_model, output_dir)
+    args = argparse.Namespace()
+    args.batch_size = config.nsf.args.batch_size
+    args.epochs = config.nsf.args.epochs
+    args.no_best_epochs = config.nsf.args.no_best_epochs
+    args.lr = config.nsf.args.lr
+    args.no_cuda = config.nsf.args.no_cuda
+    args.seed = config.nsf.args.seed
+    args.eval_mode_for_validation = config.nsf.args.eval_mode_for_validation
+    args.model_forward_with_target = config.nsf.args.model_forward_with_target
+    args.model_forward_with_file_name = config.nsf.args.model_forward_with_file_name
+    args.shuffle = config.nsf.args.shuffle
+    args.num_workers = config.nsf.args.num_workers
+    args.multi_gpu_data_parallel = config.nsf.args.multi_gpu_data_parallel
+    if config.nsf.args.save_model_dir != None:
+        args.save_model_dir = to_absolute_path(config.nsf.args.save_model_dir)
+    else:
+        args.save_model_dir = None 
+    args.not_save_each_epoch = config.nsf.args.not_save_each_epoch
+    args.save_epoch_name = config.nsf.args.save_epoch_name
+    args.save_trained_name = config.nsf.args.save_trained_name
+    args.save_model_ext = config.nsf.args.save_model_ext
+    if config.nsf.args.trained_model != None:
+        args.trained_model = to_absolute_path(config.nsf.args.trained_model)
+    else:
+        args.trained_model = None
+    args.ignore_training_history_in_trained_model = config.nsf.args.ignore_training_history_in_trained_model
+    args.inference = config.nsf.args.inference
+    # args.output_dir is set to config.nsf.model.test_output_dirs for inference stage
+    if config.nsf.model.test_output_dirs != None:
+        args.output_dir = to_absolute_path(config.nsf.model.test_output_dirs)
+    else:
+        args.output_dir=None
+    args.optimizer = config.nsf.args.optimizer
+    args.verbose = config.nsf.args.verbose
     
-    if not config.nsf.args.inference:
+    torch.manual_seed(args.seed)
+    use_cuda = not args.no_cuda and torch.cuda.is_available()
+    device = torch.device("cuda" if use_cuda else "cpu")
+    
+    if not args.inference:
         # prepare data io    
-        params = {'batch_size':  config.nsf.args.batch_size,
-                  'shuffle':  config.nsf.args.shuffle,
-                  'num_workers': config.nsf.args.num_workers}
+        params = {'batch_size':  args.batch_size,
+                  'shuffle':  args.shuffle,
+                  'num_workers': args.num_workers}
 
         # Load file list and create data loader
         train_list_path = to_absolute_path(config.data.train_no_dev.list_path)
@@ -81,7 +115,7 @@ def my_app(config : DictConfig) -> None:
                                               config.nsf.model.output_dims, 
                                               config.nsf.model.output_reso, 
                                               config.nsf.model.output_norm, 
-                                              config.nsf.args.save_model_dir,
+                                              args.save_model_dir,
                                               params = params,
                                               truncate_seq = config.nsf.model.truncate_seq, 
                                               min_seq_len = config.nsf.model.minimum_len,
@@ -114,7 +148,7 @@ def my_app(config : DictConfig) -> None:
                                             config.nsf.model.output_dims,
                                             config.nsf.model.output_reso,
                                             config.nsf.model.output_norm,
-                                            config.nsf.args.save_model_dir,
+                                            args.save_model_dir,
                                             params = params,
                                             truncate_seq= config.nsf.model.truncate_seq, 
                                             min_seq_len = config.nsf.model.minimum_len,
@@ -122,26 +156,23 @@ def my_app(config : DictConfig) -> None:
                                             wav_samp_rate = config.nsf.model.wav_samp_rate)
         
         # Initialize the model and loss function
-        # Originally nsf_mode.Model requires args as Namespace Object, not DictConfig object.
-        # But hydra uses ArgumentParser internally so we can't use nii_arg_parse.f_args_parsed().
-        # Ugly duck typing :(
         model = nsf_model.Model(train_set.get_in_dim(),
                                 train_set.get_out_dim(), 
-                                config.nsf.args, train_set.get_data_mean_std())
-        loss_wrapper = nsf_model.Loss(config.nsf.args)
+                                args, train_set.get_data_mean_std())
+        loss_wrapper = nsf_model.Loss(args)
 
         # initialize the optimizer
-        optimizer_wrapper = nii_op_wrapper.OptimizerWrapper(model, config.nsf.args)
+        optimizer_wrapper = nii_op_wrapper.OptimizerWrapper(model, args)
 
         # if necessary, resume training
-        if not config.nsf.args.trained_model:
+        if not args.trained_model:
             checkpoint = None 
         else:
-            checkpoint = torch.load(to_absolute_path(config.nsf.args.trained_model))
+            checkpoint = torch.load(args.trained_model)
             
             # start training
         logger.info(f"Start {config.nsf_type} training. This may take several days.")
-        nii_nn_wrapper.f_train_wrapper(config.nsf.args, model, 
+        nii_nn_wrapper.f_train_wrapper(args, model, 
                                        loss_wrapper, device,
                                        optimizer_wrapper,
                                        train_set, val_set, checkpoint)
@@ -149,9 +180,9 @@ def my_app(config : DictConfig) -> None:
         # for inference
 
         # default, no truncating, no shuffling
-        params = {'batch_size':  config.nsf.args.batch_size,
+        params = {'batch_size':  args.batch_size,
                   'shuffle':  False,
-                  'num_workers': config.nsf.args.num_workers}
+                  'num_workers': args.num_workers}
         test_list_path = to_absolute_path(config.data.eval.list_path)
         test_list = nii_list_tool.read_list_from_text(test_list_path)
 
@@ -166,11 +197,6 @@ def my_app(config : DictConfig) -> None:
         input_norm = copy.deepcopy(config.nsf.model.input_norm)
 
         test_input_dirs = [to_absolute_path(x) for x in config.nsf.model.test_input_dirs]
-        # Overwrite output_dir setting
-        logger.info(f"NSF setting of config.nsf.args.output_dir is overwritten with {config.nsf.model.test_output_dirs} by NNSVS.")
-        config.nsf.args.output_dir = to_absolute_path(config.nsf.model.test_output_dirs)
-
-        save_model_dir = to_absolute_path(config.nsf.args.save_model_dir)
 
         test_set = nii_dset.NIIDataSetLoader("eval",
                                              test_list, 
@@ -184,32 +210,29 @@ def my_app(config : DictConfig) -> None:
                                              config.nsf.model.output_dims, 
                                              config.nsf.model.output_reso, 
                                              config.nsf.model.output_norm, 
-                                             save_model_dir, 
+                                             args.save_model_dir, 
                                              params = params,
                                              truncate_seq = None,
                                              min_seq_len = None,
                                              save_mean_std = False,
                                              wav_samp_rate = config.nsf.model.wav_samp_rate)
         # Initialize the model
-        # Originally nsf_mode.Model requires args as Namespace Object, not DictConfig object.
-        # But hydra uses ArgumentParser internally so we can't use nii_arg_parse.f_args_parsed().
-        # Ugly duck typing :(
         model = nsf_model.Model(test_set.get_in_dim(),
                                 test_set.get_out_dim(), 
-                                config.nsf.args)
+                                args)
 
-        if not config.nsf.args.trained_model:
-            print("config.nsf.args.trained_model is not set, so try to load default trained model")
-            default_trained_model_path = to_absolute_path(join(config.nsf.args.save_model_dir,
-                                                               "{}{}".format(config.nsf.args.save_trained_name,
-                                                                             config.nsf.args.save_model_ext)))
+        if not args.trained_model:
+            print("trained_model is not set, so try to load default trained model")
+            default_trained_model_path = join(args.save_model_dir,
+                                              "{}{}".format(args.save_trained_name,
+                                                            args.save_model_ext))
             if not exists(default_trained_model_path):
                 raise Exception("No trained model found")
             checkpoint = torch.load(default_trained_model_path)
         else:
-            checkpoint = torch.load(to_absolute_path(config.nsf.args.trained_model))
+            checkpoint = torch.load(args.trained_model)
         # do inference and output data
-        nii_nn_wrapper.f_inference_wrapper(config.nsf.args, model, device,
+        nii_nn_wrapper.f_inference_wrapper(args, model, device,
                                            test_set, checkpoint)
 
 def entry():

--- a/egs/nit-song070/01-svs-nsf/conf
+++ b/egs/nit-song070/01-svs-nsf/conf
@@ -1,0 +1,1 @@
+../../kiritan_singing/00-svs-world/conf

--- a/egs/nit-song070/01-svs-nsf/run.sh
+++ b/egs/nit-song070/01-svs-nsf/run.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+script_dir=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
+NNSVS_ROOT=$script_dir/../../../
+
+spk="yoko"
+
+dumpdir=dump
+
+# HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path=./conf/jp_qst001_nnsvs.hed
+
+# speficy if you have it locally, otherwise it will be downloaded at stage -1
+hts_demo_root=downloads/HTS-demo_NIT-SONG070-F001
+
+# Pretrained model dir
+# leave empty to disable
+pretrained_expdir=
+
+batch_size=4
+
+stage=0
+stop_stage=0
+
+# exp tag
+tag="" # tag for managing experiments.
+
+. $NNSVS_ROOT/utils/parse_options.sh || exit 1;
+
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+function xrun () {
+    set -x
+    $@
+    set +x
+}
+
+train_set="train_no_dev"
+dev_set="dev"
+eval_set="eval"
+datasets=($train_set $dev_set $eval_set)
+testsets=($dev_set $eval_set)
+
+dump_org_dir=$dumpdir/$spk/org
+dump_norm_dir=$dumpdir/$spk/norm
+
+# exp name
+if [ -z ${tag} ]; then
+    expname=${spk}
+else
+    expname=${spk}_${tag}
+fi
+expdir=exp/$expname
+
+# NSF related settings.
+sample_rate=16000
+# The bap(Band Aperiodic-ity) dimension of 16kHz is 3 and differs from that of 48kHz(15).
+acoustic_model_stream_sizes=[180,3,1,3]
+# 180+3+1+3
+acoustic_model_out_dim=187
+
+nsf_root_dir=downloads/project-NN-Pytorch-scripts/
+nsf_save_model_dir=$expdir/nsf/train_outputs
+nsf_pretrained_model=
+
+if [ ${stage} -le -1 ] && [ ${stop_stage} -ge -1 ]; then
+    if [ ! -e downloads/HTS-demo_NIT-SONG070-F001 ]; then
+        echo "stage -1: Downloading data"
+        mkdir -p downloads
+        cd downloads
+        curl -LO http://hts.sp.nitech.ac.jp/archives/2.3/HTS-demo_NIT-SONG070-F001.tar.bz2
+        tar jxvf HTS-demo_NIT-SONG070-F001.tar.bz2
+    fi
+fi
+
+if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
+    echo "stage 0: Data preparation"
+    # the following three directories will be created
+    # 1) data/timelag 2) data/duration 3) data/acoustic
+    python utils/data_prep.py $hts_demo_root ./data --gain-normalize --sample-rate $sample_rate
+
+    echo "train/dev/eval split"
+    mkdir -p data/list
+    find data/acoustic/ -type f -name "*.wav" -exec basename {} .wav \; \
+        | sort > data/list/utt_list.txt
+    grep _003 data/list/utt_list.txt > data/list/$eval_set.list
+    grep _004 data/list/utt_list.txt > data/list/$dev_set.list
+    grep -v _003 data/list/utt_list.txt | grep -v _004 > data/list/$train_set.list
+fi
+
+if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
+    echo "stage 1: Feature generation"
+
+    for s in ${datasets[@]};
+    do
+      nnsvs-prepare-features utt_list=data/list/$s.list out_dir=$dump_org_dir/$s/  \
+			     question_path=$question_path \
+			     acoustic.use_harvest=false
+      
+    done
+
+    # Compute normalization stats for each input/output
+    mkdir -p $dump_norm_dir
+    for inout in "in" "out"; do
+        if [ $inout = "in" ]; then
+            scaler_class="sklearn.preprocessing.MinMaxScaler"
+        else
+            scaler_class="sklearn.preprocessing.StandardScaler"
+        fi
+        for typ in timelag duration acoustic;
+        do
+            find $dump_org_dir/$train_set/${inout}_${typ} -name "*feats.npy" > train_list.txt
+            scaler_path=$dump_org_dir/${inout}_${typ}_scaler.joblib
+            nnsvs-fit-scaler list_path=train_list.txt scaler.class=$scaler_class \
+                out_path=$scaler_path
+            rm -f train_list.txt
+            cp -v $scaler_path $dump_norm_dir/${inout}_${typ}_scaler.joblib
+        done
+    done
+
+    # apply normalization
+    for s in ${datasets[@]}; do
+        for inout in "in" "out"; do
+            for typ in timelag duration acoustic;
+            do
+                nnsvs-preprocess-normalize in_dir=$dump_org_dir/$s/${inout}_${typ}/ \
+                    scaler_path=$dump_org_dir/${inout}_${typ}_scaler.joblib \
+                    out_dir=$dump_norm_dir/$s/${inout}_${typ}/
+            done
+        done
+    done
+fi
+
+if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
+    echo "stage 2: Training time-lag model"
+    if [ ! -z "${pretrained_expdir}" ]; then
+        resume_checkpoint=$pretrained_expdir/timelag/latest.pth
+    else
+        resume_checkpoint=
+    fi
+   xrun nnsvs-train data.train_no_dev.in_dir=$dump_norm_dir/$train_set/in_timelag/ \
+        data.train_no_dev.out_dir=$dump_norm_dir/$train_set/out_timelag/ \
+        data.dev.in_dir=$dump_norm_dir/$dev_set/in_timelag/ \
+        data.dev.out_dir=$dump_norm_dir/$dev_set/out_timelag/ \
+        model=timelag train.out_dir=$expdir/timelag \
+        data.batch_size=$batch_size \
+        resume.checkpoint=$resume_checkpoint
+fi
+
+if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
+    echo "stage 3: Training phoneme duration model"
+    if [ ! -z "${pretrained_expdir}" ]; then
+        resume_checkpoint=$pretrained_expdir/duration/latest.pth
+    else
+        resume_checkpoint=
+    fi
+    xrun nnsvs-train data.train_no_dev.in_dir=$dump_norm_dir/$train_set/in_duration/ \
+        data.train_no_dev.out_dir=$dump_norm_dir/$train_set/out_duration/ \
+        data.dev.in_dir=$dump_norm_dir/$dev_set/in_duration/ \
+        data.dev.out_dir=$dump_norm_dir/$dev_set/out_duration/ \
+        model=duration train.out_dir=$expdir/duration \
+        data.batch_size=$batch_size \
+        resume.checkpoint=$resume_checkpoint
+fi
+
+
+if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
+    echo "stage 4: Training acoustic model"
+    if [ ! -z "${pretrained_expdir}" ]; then
+        resume_checkpoint=$pretrained_expdir/acoustic/latest.pth
+    else
+        resume_checkpoint=
+    fi
+    xrun nnsvs-train data.train_no_dev.in_dir=$dump_norm_dir/$train_set/in_acoustic/ \
+        data.train_no_dev.out_dir=$dump_norm_dir/$train_set/out_acoustic/ \
+        data.dev.in_dir=$dump_norm_dir/$dev_set/in_acoustic/ \
+        data.dev.out_dir=$dump_norm_dir/$dev_set/out_acoustic/ \
+        model=acoustic train.out_dir=$expdir/acoustic \
+        data.batch_size=$batch_size \
+        resume.checkpoint=$resume_checkpoint \
+        model.stream_sizes=$acoustic_model_stream_sizes \
+        model.netG.params.out_dim=$acoustic_model_out_dim
+fi
+
+
+# NOTE: step 5 does not generate waveform. It just saves neural net's outputs.
+if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
+    echo "stage 5: Generation features from timelag/duration/acoustic models"
+    for s in ${testsets[@]}; do
+        for typ in timelag duration acoustic; do
+            checkpoint=$expdir/$typ/latest.pth
+            name=$(basename $checkpoint)
+            xrun nnsvs-generate model.checkpoint=$checkpoint \
+                model.model_yaml=$expdir/$typ/model.yaml \
+                out_scaler_path=$dump_norm_dir/out_${typ}_scaler.joblib \
+                in_dir=$dump_norm_dir/$s/in_${typ}/ \
+                out_dir=$expdir/$typ/predicted/$s/${name%.*}/
+        done
+    done
+fi
+
+
+if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
+    echo "stage 6: Synthesis waveforms"
+    if [ ! -e $nsf_pretrained_model ]; then
+	echo "No NSF pretrained model found."
+	echo "Please run stage 7-9 or download pretrained model from somewhare."
+	exit 1
+    fi
+
+    for s in ${testsets[@]}; do
+        for input in label_phone_score label_phone_align; do
+            if [ $input = label_phone_score ]; then
+                ground_truth_duration=false
+            else
+                ground_truth_duration=true
+            fi
+	    #            xrun nnsvs-synthesis question_path=conf/jp_qst001_nnsvs.hed \
+            xrun python bin/synthesis_nsf.py question_path=conf/jp_qst001_nnsvs.hed \
+            timelag.checkpoint=$expdir/timelag/latest.pth \
+            timelag.in_scaler_path=$dump_norm_dir/in_timelag_scaler.joblib \
+            timelag.out_scaler_path=$dump_norm_dir/out_timelag_scaler.joblib \
+            timelag.model_yaml=$expdir/timelag/model.yaml \
+            duration.checkpoint=$expdir/duration/latest.pth \
+            duration.in_scaler_path=$dump_norm_dir/in_duration_scaler.joblib \
+            duration.out_scaler_path=$dump_norm_dir/out_duration_scaler.joblib \
+            duration.model_yaml=$expdir/duration/model.yaml \
+            acoustic.checkpoint=$expdir/acoustic/latest.pth \
+            acoustic.in_scaler_path=$dump_norm_dir/in_acoustic_scaler.joblib \
+            acoustic.out_scaler_path=$dump_norm_dir/out_acoustic_scaler.joblib \
+            acoustic.model_yaml=$expdir/acoustic/model.yaml \
+            acoustic.stream_sizes=$acoustic_model_stream_sizes \
+            utt_list=./data/list/$s.list \
+            in_dir=data/acoustic/$input/ \
+            out_dir=$expdir/synthesis/$s/latest/$input \
+            ground_truth_duration=$ground_truth_duration \
+	    nsf_root_dir=downloads/project-NN-Pytorch-scripts/ \
+	    nsf.args.save_model_dir=$nsf_save_model_dir \
+        nsf.args.trained_model=$nsf_pretrained_model
+        done
+    done
+fi
+
+if [ ${stage} -le 7 ] && [ ${stop_stage} -ge 7 ]; then
+    if [ ! -e $nsf_root_dir ]; then
+	echo "stage 7: Downloading NSF"
+        mkdir -p downloads
+        cd downloads
+	git clone https://github.com/nii-yamagishilab/project-NN-Pytorch-scripts
+	cd $script_dir
+    fi
+fi
+
+if [ ${stage} -le 8 ] && [ ${stop_stage} -ge 8 ]; then
+    echo "stage 8: Data preparation for NSF"
+    out_dir=$expdir/nsf
+    mkdir -p $out_dir
+    for s in ${datasets[@]};
+    do
+        if [ $s = $eval_set ]; then
+	    xrun python bin/prepare_nsf_data.py in_dir=$dump_org_dir/$s/out_acoustic out_dir=$out_dir test_set=true
+        else
+	    xrun python bin/prepare_nsf_data.py in_dir=$dump_org_dir/$s/out_acoustic out_dir=$out_dir
+	fi
+    done
+fi
+
+if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
+    echo "stage 9: Training NSF model"
+    if [ ! -e $nsf_root_dir ]; then
+	echo "No NSF files found. Please set nsf_root_dir properly or run stage 7."
+	exit 1
+    fi
+
+    input_dirs=$expdir/nsf/input_dirs
+    output_dirs=$expdir/nsf/output_dirs
+    mkdir -p $output_dirs
+    mkdir -p $nsf_save_model_dir
+    xrun python bin/train_nsf.py \
+	 nsf_root_dir=$nsf_root_dir \
+	 nsf_type=hn-sinc-nsf \
+	 nsf.args.batch_size=1 \
+	 nsf.args.epochs=500 \
+	 nsf.args.no_best_epochs=20 \
+	 nsf.args.save_model_dir=$nsf_save_model_dir \
+	 nsf.model.input_dirs=["$input_dirs","$input_dirs","$input_dirs"]\
+	 nsf.model.output_dirs=["$output_dirs"]
+fi
+
+if [ ${stage} -le 10 ] && [ ${stop_stage} -ge 10 ]; then
+    echo "stage 10: Evaluating NSF model"
+    if [ ! -e $nsf_root_dir ]; then
+	echo "No NSF files found. Please set nsf_root_dir properly or run stage 7."
+	exit 1
+    fi
+
+    # for inference
+    test_input_dirs=$expdir/nsf/test_input_dirs
+    test_output_dirs=$expdir/nsf/test_output_dirs
+    mkdir -p $test_output_dirs
+    xrun python bin/train_nsf.py \
+	 nsf_root_dir=$nsf_root_dir \
+	 nsf_type=hn-sinc-nsf \
+	 nsf.args.batch_size=1 \
+	 nsf.args.save_model_dir=$nsf_save_model_dir \
+	 nsf.args.trained_model=$nsf_pretrained_model \
+	 nsf.args.inference=true \
+	 nsf.model.test_input_dirs=["$test_input_dirs","$test_input_dirs","$test_input_dirs"]\
+	 nsf.model.test_output_dirs=$test_output_dirs
+
+fi

--- a/egs/nit-song070/01-svs-nsf/run.sh
+++ b/egs/nit-song070/01-svs-nsf/run.sh
@@ -65,7 +65,7 @@ acoustic_model_out_dim=187
 
 nsf_root_dir=downloads/project-NN-Pytorch-scripts/
 nsf_save_model_dir=$expdir/nsf/train_outputs
-nsf_pretrained_model=
+nsf_pretrained_model=$expdir/nsf/train_outputs/trained_network.pt
 
 if [ ${stage} -le -1 ] && [ ${stop_stage} -ge -1 ]; then
     if [ ! -e downloads/HTS-demo_NIT-SONG070-F001 ]; then
@@ -284,9 +284,11 @@ if [ ${stage} -le 9 ] && [ ${stop_stage} -ge 9 ]; then
 	 nsf_root_dir=$nsf_root_dir \
 	 nsf_type=hn-sinc-nsf \
 	 nsf.args.batch_size=1 \
-	 nsf.args.epochs=500 \
-	 nsf.args.no_best_epochs=20 \
+	 nsf.args.epochs=100 \
+	 nsf.args.no_best_epochs=5 \
+	 nsf.args.lr=0.00003 \
 	 nsf.args.save_model_dir=$nsf_save_model_dir \
+	 nsf.args.trained_model=$nsf_pretrained_model \
 	 nsf.model.input_dirs=["$input_dirs","$input_dirs","$input_dirs"]\
 	 nsf.model.output_dirs=["$output_dirs"]
 fi

--- a/egs/nit-song070/01-svs-nsf/utils/data_prep.py
+++ b/egs/nit-song070/01-svs-nsf/utils/data_prep.py
@@ -1,0 +1,221 @@
+# coding: utf-8
+import os
+
+import argparse
+from glob import glob
+from os.path import join, basename, splitext, exists, expanduser
+from nnmnkwii.io import hts
+from scipy.io import wavfile
+import librosa
+import soundfile as sf
+import sys
+import numpy as np
+from nnsvs.io.hts import get_note_indices
+
+
+def _is_silence(l):
+    is_full_context = "@" in l
+    if is_full_context:
+        is_silence = ("-sil" in l or "-pau" in l)
+    else:
+        is_silence = (l == "sil" or l == "pau")
+    return is_silence
+
+
+def remove_sil_and_pau(lab):
+    newlab = hts.HTSLabelFile()
+    for l in lab:
+        if "-sil" not in l[-1] and "-pau" not in l[-1]:
+            newlab.append(l, strict=False)
+
+    return newlab
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Data preparation for NIT-SONG070",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("hts_demo_root", type=str, help="HTS demo root")
+    parser.add_argument("out_dir", type=str, help="Output directory")
+    parser.add_argument("--gain-normalize", action='store_true')
+    parser.add_argument("--sample-rate", type=int, default=48000, help="Audio sampling rate (default 48000)")
+    return parser
+
+args = get_parser().parse_args(sys.argv[1:])
+
+hts_demo_root = args.hts_demo_root
+out_dir = args.out_dir
+hts_label_root = join(hts_demo_root, "data/labels")
+gain_normalize = args.gain_normalize
+sample_rate = args.sample_rate
+
+# Time-lag constraints to filter outliers
+timelag_allowed_range = (-20, 19)
+timelag_allowed_range_rest = (-40, 39)
+
+offset_correction_threshold = 0.005
+
+mono_dir = join(hts_label_root, "mono")
+full_dir = join(hts_label_root, "full")
+
+### Make aligned full context labels
+
+# Note: this will be saved under hts_label_root directory
+full_align_dir = join(hts_label_root, "full_align")
+os.makedirs(full_align_dir, exist_ok=True)
+
+mono_lab_files = sorted(glob(join(mono_dir, "*.lab")))
+full_lab_files = sorted(glob(join(full_dir, "*.lab")))
+for m, f in zip(mono_lab_files, full_lab_files):
+    mono_lab = hts.load(m)
+    full_lab = hts.load(f)
+    assert len(mono_lab) == len(full_lab)
+    full_lab.start_times = mono_lab.start_times
+    full_lab.end_times = mono_lab.end_times
+    name = basename(m)
+    dst_path = join(full_align_dir, name)
+    with open(dst_path, "w") as of:
+        of.write(str(full_lab))
+
+### Prepare data for time-lag models
+
+dst_dir = join(out_dir, "timelag")
+lab_align_dst_dir  = join(dst_dir, "label_phone_align")
+lab_score_dst_dir  = join(dst_dir, "label_phone_score")
+
+for d in [lab_align_dst_dir, lab_score_dst_dir]:
+    os.makedirs(d, exist_ok=True)
+
+print("Prepare data for time-lag models")
+full_lab_align_files = sorted(glob(join(full_align_dir, "*.lab")))
+for lab_align_path in full_lab_align_files:
+    lab_score_path = join(full_dir, basename(lab_align_path))
+    assert exists(lab_score_path)
+    name = basename(lab_align_path)
+
+    lab_align = hts.load(lab_align_path)
+    lab_score = hts.load(lab_score_path)
+
+    # Extract note onsets and let's compute a offset
+    note_indices = get_note_indices(lab_score)
+
+    onset_align = np.asarray(lab_align[note_indices].start_times)
+    onset_score = np.asarray(lab_score[note_indices].start_times)
+
+    global_offset = (onset_align - onset_score).mean()
+    global_offset = int(round(global_offset / 50000) * 50000)
+
+    # Apply offset correction only when there is a big gap
+    apply_offset_correction = np.abs(global_offset * 1e-7) > offset_correction_threshold
+    if apply_offset_correction:
+        print(f"{name}: Global offset (in sec): {global_offset * 1e-7}")
+        lab_score.start_times = list(np.asarray(lab_score.start_times) + global_offset)
+        lab_score.end_times = list(np.asarray(lab_score.end_times) + global_offset)
+        onset_score += global_offset
+
+    # Exclude large diff parts (probably a bug of musicxml or alignment though)
+    valid_note_indices = []
+    for idx, (a, b) in enumerate(zip(onset_align, onset_score)):
+        note_idx = note_indices[idx]
+        lag = np.abs(a - b) / 50000
+        if _is_silence(lab_score.contexts[note_idx]):
+            if lag >= timelag_allowed_range_rest[0] and lag <= timelag_allowed_range_rest[1]:
+                valid_note_indices.append(note_idx)
+        else:
+            if lag >= timelag_allowed_range[0] and lag <= timelag_allowed_range[1]:
+                valid_note_indices.append(note_idx)
+
+    if len(valid_note_indices) < len(note_indices):
+        D = len(note_indices) - len(valid_note_indices)
+        print(f"{name}: {D}/{len(note_indices)} time-lags are excluded.")
+
+    # Note onsets as labels
+    lab_align = lab_align[valid_note_indices]
+    lab_score = lab_score[valid_note_indices]
+
+    # Save lab files
+    lab_align_dst_path = join(lab_align_dst_dir, name)
+    with open(lab_align_dst_path, "w") as of:
+        of.write(str(lab_align))
+
+    lab_score_dst_path = join(lab_score_dst_dir, name)
+    with open(lab_score_dst_path, "w") as of:
+        of.write(str(lab_score))
+
+### Prepare data for duration models
+
+dst_dir = join(out_dir, "duration")
+lab_align_dst_dir  = join(dst_dir, "label_phone_align")
+
+for d in [lab_align_dst_dir]:
+    os.makedirs(d, exist_ok=True)
+
+print("Prepare data for duration models")
+full_lab_align_files = sorted(glob(join(full_align_dir, "*.lab")))
+for lab_align_path in full_lab_align_files:
+    name = basename(lab_align_path)
+
+    lab_align = hts.load(lab_align_path)
+
+    # Save lab file
+    lab_align_dst_path = join(lab_align_dst_dir, name)
+    with open(lab_align_dst_path, "w") as of:
+        of.write(str(lab_align))
+
+
+### Prepare data for acoustic models
+
+dst_dir = join(out_dir, "acoustic")
+wav_dst_dir  = join(dst_dir, "wav")
+lab_align_dst_dir  = join(dst_dir, "label_phone_align")
+lab_score_dst_dir  = join(dst_dir, "label_phone_score")
+
+for d in [wav_dst_dir, lab_align_dst_dir, lab_score_dst_dir]:
+    os.makedirs(d, exist_ok=True)
+
+print("Prepare data for acoustic models")
+full_lab_align_files = sorted(glob(join(full_align_dir, "*.lab")))
+for lab_align_path in full_lab_align_files:
+    name = splitext(basename(lab_align_path))[0]
+    lab_score_path = join(full_dir, name + ".lab")
+    assert exists(lab_score_path)
+    wav_path = join(hts_demo_root, "data", "wav", name + ".wav")
+    raw_path = join(hts_demo_root, "data", "raw", name + ".raw")
+
+    # We can load and manupulate audio (e.g., normalizing gain), but for now just copy it as is
+    if exists(wav_path):
+        # sr, wave = wavfile.read(wav_path)
+        wav, sr = librosa.load(wav_path, sr=sample_rate)
+    else:
+        assert raw_path
+        wav = np.fromfile(raw_path, dtype=np.int16)
+        wav = wav.astype(np.float32) / 2**15
+        raw_sr = 48000
+        if sample_rate != raw_sr:
+            wav = librosa.core.resample(wav, raw_sr, sample_rate)
+            sr = sample_rate
+        else:
+            sr = raw_sr
+
+    if gain_normalize:
+        wav = wav / wav.max() * 0.99
+
+    lab_align = hts.load(lab_align_path)
+    lab_score = hts.load(lab_score_path)
+
+    # Save caudio
+    wav_dst_path = join(wav_dst_dir, name + ".wav")
+    # TODO: consider explicit subtype
+    sf.write(wav_dst_path, wav, sr)
+
+    # Save label
+    lab_align_dst_path = join(lab_align_dst_dir, name + ".lab")
+    with open(lab_align_dst_path, "w") as of:
+        of.write(str(lab_align))
+
+    lab_score_dst_path = join(lab_score_dst_dir, name + ".lab")
+    with open(lab_score_dst_path, "w") as of:
+        of.write(str(lab_score))
+
+sys.exit(0)


### PR DESCRIPTION
Hello. I made sample implementation of [Neural Source Filter waveform models(NSF)](https://nii-yamagishilab.github.io/samples-nsf/) support.

1. If nsf_root_dir is unspecified or not found, run.sh download NSF into downloads directory automatically.
2. All NSF related data and outputs are stored in exp/yoko/nsf.
3. I could not find the rules about assigning stage no, so I assign stage 7-10 to each NSF related process(downloading, data preparation, training, evaluation).
4. Training data are the combination of mgc,f0,bap and extracted from dump/org/\*/out_acoustic/\*.npy.  The process of training NSF  seems to work well as far as I listen to the output of NSF evaluation(it is stored in exp/yoko/nsf/test_output_dirs and the data to synthesize this are directly extracted from original wav file).  But when using acoustic features generated by NNSVS, sound quality of generated wavs are unsatisfactory.
5. For convenience I prepare the pretrained NSF model(https://drive.google.com/file/d/1EIaeiQukNt7lsXSqFVWzryujFhUdqkgi/view?usp=sharing).

Please advise me to improve quality of sounds.
