### PR TITLE
Setup.py fails on Windows due to file encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = SourceFileLoader('nnsvs.version', 'nnsvs/version.py').load_module().ve
 
 packages = find_packages()
 if exists("README.md"):
-    with open("README.md", "r") as fh:
+    with open("README.md", "r", encoding="UTF-8") as fh:
         LONG_DESC = LONG_DESC = fh.read()
 else:
     LONG_DESC = ""


### PR DESCRIPTION
When I try to install nnsvs with setup.py on windows(winpython), I get the error as follows;

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\<snip>\AppData\Local\Temp\pip-req-build-nu1mer21\setup.py", line 11, in <module>
        LONG_DESC = LONG_DESC = fh.read()
    UnicodeDecodeError: 'cp932' codec can't decode byte 0x94 in position 2941: illegal multibyte sequence

The default encoding of Windows is CP932, so python on windows tries to open README.md as CP932 encoded-text and results in failure.  This is solved by explicitly specifying the encoding when opening.