### PR TITLE
nit-song070/00-svs-world error when running from stage -1 to stage 1 consecutively

### DIFF
--- a/egs/nit-song070/00-svs-world/run.sh
+++ b/egs/nit-song070/00-svs-world/run.sh
@@ -63,6 +63,7 @@ if [ ${stage} -le -1 ] && [ ${stop_stage} -ge -1 ]; then
         cd downloads
         curl -LO http://hts.sp.nitech.ac.jp/archives/2.3/HTS-demo_NIT-SONG070-F001.tar.bz2
         tar jxvf HTS-demo_NIT-SONG070-F001.tar.bz2
+        cd $script_dir
     fi
 fi
 


### PR DESCRIPTION
When I run nit-song070/00-svs-world recipe from stage -1 to stage 0 consecutively, I got the error as follows;

stage 0: Data preparation
D:\\<snip>\\miniconda3\\envs\\nnsvs\\python.exe: can't open file 'utils/data_prep.py': [Errno 2] No such file or directory
(nnsvs)

This is solved by changing the current directory to $script_dir after extracting HTS-demo_NIT-SONG070-F001.tar.bz2.
