### PR TITLE
Stream-wise training

### DIFF
--- a/egs/nit-song070/05-swt-world/README.md
+++ b/egs/nit-song070/05-swt-world/README.md
@@ -1,0 +1,9 @@
+# 00-svs-world
+
+A recipe to build a statistical parametric singing voice synthesis system. The system consists of three trainable networks:
+
+1. Time-lag model
+2. Duration model
+3. Acoustic model
+
+The recipe structure is almost the same as [kiritan_singing/00-svs-world](../../kiritan_singing/00-svs-world). Please check the README of kiritan database for more details.

--- a/egs/nit-song070/05-swt-world/conf
+++ b/egs/nit-song070/05-swt-world/conf
@@ -1,0 +1,1 @@
+../../kiritan_singing/00-svs-world/conf

--- a/egs/nit-song070/05-swt-world/hydra/train/config.yaml
+++ b/egs/nit-song070/05-swt-world/hydra/train/config.yaml
@@ -1,0 +1,52 @@
+# @package _global_
+
+defaults:
+  - hydra/job_logging: colorlog
+  - hydra/hydra_logging: colorlog
+  - model: acoustic
+
+verbose: 100
+
+data:
+  # training set
+  train_no_dev:
+    in_dir:
+    out_dir:
+
+  # development set
+  dev:
+    in_dir:
+    out_dir:
+
+  # data loader
+  num_workers: 2
+  batch_size: 8
+  pin_memory: true
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.5, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+
+train:
+  out_dir: exp
+  nepochs: 50
+  checkpoint_epoch_interval: 20
+
+  stream_wise_loss: false
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: false

--- a/egs/nit-song070/05-swt-world/hydra/train/model/acoustic.yaml
+++ b/egs/nit-song070/05-swt-world/hydra/train/model/acoustic.yaml
@@ -1,0 +1,42 @@
+# @package _group_
+# (mgc, lf0, vuv, bap)
+stream_sizes: [180, 3, 1, 15]
+has_dynamic_features: [true, true, false, true]
+num_windows: 3
+# If None, automatically set based on stream sizes
+stream_weights:
+stream_wise_training: true
+
+models:
+  # mgc
+  - netG:
+      _target_: nnsvs.model.Conv1dResnet
+      in_dim: 424
+      out_dim: 180
+      hidden_dim: 128
+      num_layers: 6
+      dropout: 0.1
+  # f0
+  - netG:
+      _target_: nnsvs.model.LSTMRNN
+      in_dim: 424
+      out_dim: 3
+      hidden_dim: 64
+      num_layers: 2
+      dropout: 0.1
+  # vuv
+  - netG:
+      _target_: nnsvs.model.Conv1dResnet
+      in_dim: 424
+      out_dim: 1
+      hidden_dim: 128
+      num_layers: 6
+      dropout: 0.1
+  # bap
+  - netG:
+      _target_: nnsvs.model.Conv1dResnet
+      in_dim: 424
+      out_dim: 15
+      hidden_dim: 128
+      num_layers: 6
+      dropout: 0.1

--- a/egs/nit-song070/05-swt-world/run.sh
+++ b/egs/nit-song070/05-swt-world/run.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+
+script_dir=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
+NNSVS_ROOT=$script_dir/../../../
+
+spk="yoko"
+
+dumpdir=dump
+
+# HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path=./conf/jp_qst001_nnsvs.hed
+
+# speficy if you have it locally, otherwise it will be downloaded at stage -1
+hts_demo_root=downloads/HTS-demo_NIT-SONG070-F001
+
+# Pretrained model dir
+# leave empty to disable
+pretrained_expdir=
+
+batch_size=4
+
+stage=0
+stop_stage=0
+
+# exp tag
+tag="" # tag for managing experiments.
+
+. $NNSVS_ROOT/utils/parse_options.sh || exit 1;
+
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+function xrun () {
+    set -x
+    $@
+    set +x
+}
+
+train_set="train_no_dev"
+dev_set="dev"
+eval_set="eval"
+datasets=($train_set $dev_set $eval_set)
+testsets=($dev_set $eval_set)
+
+dump_org_dir=$dumpdir/$spk/org
+dump_norm_dir=$dumpdir/$spk/norm
+
+# exp name
+if [ -z ${tag} ]; then
+    expname=${spk}
+else
+    expname=${spk}_${tag}
+fi
+expdir=exp/$expname
+
+if [ ${stage} -le -1 ] && [ ${stop_stage} -ge -1 ]; then
+    if [ ! -e downloads/HTS-demo_NIT-SONG070-F001 ]; then
+        echo "stage -1: Downloading data"
+        mkdir -p downloads
+        cd downloads
+        curl -LO http://hts.sp.nitech.ac.jp/archives/2.3/HTS-demo_NIT-SONG070-F001.tar.bz2
+        tar jxvf HTS-demo_NIT-SONG070-F001.tar.bz2
+        cd $script_dir
+    fi
+fi
+
+if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
+    echo "stage 0: Data preparation"
+    # the following three directories will be created
+    # 1) data/timelag 2) data/duration 3) data/acoustic
+    python utils/data_prep.py $hts_demo_root ./data --gain-normalize
+    
+    echo "train/dev/eval split"
+    mkdir -p data/list
+    find data/acoustic/ -type f -name "*.wav" -exec basename {} .wav \; \
+        | sort > data/list/utt_list.txt
+    grep _003 data/list/utt_list.txt > data/list/$eval_set.list
+    grep _004 data/list/utt_list.txt > data/list/$dev_set.list
+    grep -v _003 data/list/utt_list.txt | grep -v _004 > data/list/$train_set.list
+fi
+
+if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
+    echo "stage 1: Feature generation"
+    
+    for s in ${datasets[@]};
+    do
+	nnsvs-prepare-features utt_list=data/list/$s.list out_dir=$dump_org_dir/$s/  \
+			     question_path=$question_path
+    done
+
+    # Compute normalization stats for each input/output
+    mkdir -p $dump_norm_dir
+    for inout in "in" "out"; do
+        if [ $inout = "in" ]; then
+            scaler_class="sklearn.preprocessing.MinMaxScaler"
+        else
+            scaler_class="sklearn.preprocessing.StandardScaler"
+        fi
+        for typ in timelag duration acoustic;
+        do
+            find $dump_org_dir/$train_set/${inout}_${typ} -name "*feats.npy" > train_list.txt
+            scaler_path=$dump_org_dir/${inout}_${typ}_scaler.joblib
+            nnsvs-fit-scaler list_path=train_list.txt scaler.class=$scaler_class \
+			     out_path=$scaler_path
+            rm -f train_list.txt
+            cp -v $scaler_path $dump_norm_dir/${inout}_${typ}_scaler.joblib
+        done
+    done
+
+    # apply normalization
+    for s in ${datasets[@]}; do
+        for inout in "in" "out"; do
+            for typ in timelag duration acoustic;
+            do
+                nnsvs-preprocess-normalize in_dir=$dump_org_dir/$s/${inout}_${typ}/ \
+					   scaler_path=$dump_org_dir/${inout}_${typ}_scaler.joblib \
+					   out_dir=$dump_norm_dir/$s/${inout}_${typ}/
+            done
+        done
+    done
+fi
+
+if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
+    echo "stage 2: Training time-lag model"
+    if [ ! -z "${pretrained_expdir}" ]; then
+        resume_checkpoint=$pretrained_expdir/timelag/latest.pth
+    else
+        resume_checkpoint=
+    fi
+   xrun nnsvs-train data.train_no_dev.in_dir=$dump_norm_dir/$train_set/in_timelag/ \
+        data.train_no_dev.out_dir=$dump_norm_dir/$train_set/out_timelag/ \
+        data.dev.in_dir=$dump_norm_dir/$dev_set/in_timelag/ \
+        data.dev.out_dir=$dump_norm_dir/$dev_set/out_timelag/ \
+        model=timelag train.out_dir=$expdir/timelag \
+        data.batch_size=$batch_size \
+        resume.checkpoint=$resume_checkpoint
+fi
+
+if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
+    echo "stage 3: Training phoneme duration model"
+    if [ ! -z "${pretrained_expdir}" ]; then
+        resume_checkpoint=$pretrained_expdir/duration/latest.pth
+    else
+        resume_checkpoint=
+    fi
+    xrun nnsvs-train data.train_no_dev.in_dir=$dump_norm_dir/$train_set/in_duration/ \
+         data.train_no_dev.out_dir=$dump_norm_dir/$train_set/out_duration/ \
+         data.dev.in_dir=$dump_norm_dir/$dev_set/in_duration/ \
+         data.dev.out_dir=$dump_norm_dir/$dev_set/out_duration/ \
+         model=duration train.out_dir=$expdir/duration \
+         data.batch_size=$batch_size \
+         resume.checkpoint=$resume_checkpoint
+fi
+
+
+if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
+    echo "stage 4: Training acoustic model"
+    if [ ! -z "${pretrained_expdir}" ]; then
+        resume_checkpoint=$pretrained_expdir/acoustic/latest.pth
+    else
+        resume_checkpoint=
+    fi
+    xrun nnsvs-train --config-dir hydra/train --config-path config.yaml\
+	 data.train_no_dev.in_dir=$dump_norm_dir/$train_set/in_acoustic/ \
+         data.train_no_dev.out_dir=$dump_norm_dir/$train_set/out_acoustic/ \
+         data.dev.in_dir=$dump_norm_dir/$dev_set/in_acoustic/ \
+         data.dev.out_dir=$dump_norm_dir/$dev_set/out_acoustic/ \
+         model=acoustic train.out_dir=$expdir/acoustic \
+         data.batch_size=$batch_size \
+         resume.checkpoint=$resume_checkpoint
+fi
+
+
+# NOTE: step 5 does not generate waveform. It just saves neural net's outputs.
+if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
+    echo "stage 5: Generation features from timelag/duration/acoustic models"
+    for s in ${testsets[@]}; do
+        for typ in timelag duration; do
+            checkpoint=$expdir/$typ/latest.pth
+            name=$(basename $checkpoint)
+            xrun nnsvs-generate model.checkpoint=$checkpoint \
+                 model.model_yaml=$expdir/$typ/model.yaml \
+                 out_scaler_path=$dump_norm_dir/out_${typ}_scaler.joblib \
+                 in_dir=$dump_norm_dir/$s/in_${typ}/ \
+                 out_dir=$expdir/$typ/predicted/$s/${name%.*}/
+	done
+        for typ in acoustic; do
+            checkpoint=[$expdir/$typ/stream_0_latest.pth,$expdir/$typ/stream_1_latest.pth,$expdir/$typ/stream_2_latest.pth,$expdir/$typ/stream_3_latest.pth]
+            name=latest
+            xrun nnsvs-generate model.checkpoint=$checkpoint \
+                 model.model_yaml=$expdir/$typ/model.yaml \
+                 out_scaler_path=$dump_norm_dir/out_${typ}_scaler.joblib \
+                 in_dir=$dump_norm_dir/$s/in_${typ}/ \
+                 out_dir=$expdir/$typ/predicted/$s/${name%.*}/
+        done
+    done
+fi
+
+
+if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
+    echo "stage 6: Synthesis waveforms"
+    for s in ${testsets[@]}; do
+        for input in label_phone_score label_phone_align; do
+            if [ $input = label_phone_score ]; then
+                ground_truth_duration=false
+            else
+                ground_truth_duration=true
+            fi
+            xrun nnsvs-synthesis question_path=conf/jp_qst001_nnsvs.hed \
+            timelag.checkpoint=$expdir/timelag/latest.pth \
+            timelag.in_scaler_path=$dump_norm_dir/in_timelag_scaler.joblib \
+            timelag.out_scaler_path=$dump_norm_dir/out_timelag_scaler.joblib \
+            timelag.model_yaml=$expdir/timelag/model.yaml \
+            duration.checkpoint=$expdir/duration/latest.pth \
+            duration.in_scaler_path=$dump_norm_dir/in_duration_scaler.joblib \
+            duration.out_scaler_path=$dump_norm_dir/out_duration_scaler.joblib \
+            duration.model_yaml=$expdir/duration/model.yaml \
+            acoustic.checkpoint=[$expdir/acoustic/stream_0_latest.pth,$expdir/acoustic/stream_1_latest.pth,$expdir/acoustic/stream_2_latest.pth,$expdir/acoustic/stream_3_latest.pth] \
+            acoustic.in_scaler_path=$dump_norm_dir/in_acoustic_scaler.joblib \
+            acoustic.out_scaler_path=$dump_norm_dir/out_acoustic_scaler.joblib \
+            acoustic.model_yaml=$expdir/acoustic/model.yaml \
+            utt_list=./data/list/$s.list \
+            in_dir=data/acoustic/$input/ \
+            out_dir=$expdir/synthesis/$s/latest/$input \
+            ground_truth_duration=$ground_truth_duration
+        done
+    done
+fi

--- a/egs/nit-song070/05-swt-world/utils/data_prep.py
+++ b/egs/nit-song070/05-swt-world/utils/data_prep.py
@@ -1,0 +1,215 @@
+# coding: utf-8
+import os
+
+import argparse
+from glob import glob
+from os.path import join, basename, splitext, exists, expanduser
+from nnmnkwii.io import hts
+from scipy.io import wavfile
+import librosa
+import soundfile as sf
+import sys
+import numpy as np
+
+from nnsvs.io.hts import get_note_indices
+
+
+def _is_silence(l):
+    is_full_context = "@" in l
+    if is_full_context:
+        is_silence = ("-sil" in l or "-pau" in l)
+    else:
+        is_silence = (l == "sil" or l == "pau")
+    return is_silence
+
+
+def remove_sil_and_pau(lab):
+    newlab = hts.HTSLabelFile()
+    for l in lab:
+        if "-sil" not in l[-1] and "-pau" not in l[-1]:
+            newlab.append(l, strict=False)
+
+    return newlab
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Data preparation for NIT-SONG070",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("hts_demo_root", type=str, help="HTS demo root")
+    parser.add_argument("out_dir", type=str, help="Output directory")
+    parser.add_argument("--gain-normalize", action='store_true')
+    return parser
+
+args = get_parser().parse_args(sys.argv[1:])
+
+hts_demo_root = args.hts_demo_root
+out_dir = args.out_dir
+hts_label_root = join(hts_demo_root, "data/labels")
+gain_normalize = args.gain_normalize
+
+# Time-lag constraints to filter outliers
+timelag_allowed_range = (-20, 19)
+timelag_allowed_range_rest = (-40, 39)
+
+offset_correction_threshold = 0.005
+
+mono_dir = join(hts_label_root, "mono")
+full_dir = join(hts_label_root, "full")
+
+### Make aligned full context labels
+
+# Note: this will be saved under hts_label_root directory
+full_align_dir = join(hts_label_root, "full_align")
+os.makedirs(full_align_dir, exist_ok=True)
+
+mono_lab_files = sorted(glob(join(mono_dir, "*.lab")))
+full_lab_files = sorted(glob(join(full_dir, "*.lab")))
+for m, f in zip(mono_lab_files, full_lab_files):
+    mono_lab = hts.load(m)
+    full_lab = hts.load(f)
+    assert len(mono_lab) == len(full_lab)
+    full_lab.start_times = mono_lab.start_times
+    full_lab.end_times = mono_lab.end_times
+    name = basename(m)
+    dst_path = join(full_align_dir, name)
+    with open(dst_path, "w") as of:
+        of.write(str(full_lab))
+
+### Prepare data for time-lag models
+
+dst_dir = join(out_dir, "timelag")
+lab_align_dst_dir  = join(dst_dir, "label_phone_align")
+lab_score_dst_dir  = join(dst_dir, "label_phone_score")
+
+for d in [lab_align_dst_dir, lab_score_dst_dir]:
+    os.makedirs(d, exist_ok=True)
+
+print("Prepare data for time-lag models")
+full_lab_align_files = sorted(glob(join(full_align_dir, "*.lab")))
+for lab_align_path in full_lab_align_files:
+    lab_score_path = join(full_dir, basename(lab_align_path))
+    assert exists(lab_score_path)
+    name = basename(lab_align_path)
+
+    lab_align = hts.load(lab_align_path)
+    lab_score = hts.load(lab_score_path)
+
+    # Extract note onsets and let's compute a offset
+    note_indices = get_note_indices(lab_score)
+
+    onset_align = np.asarray(lab_align[note_indices].start_times)
+    onset_score = np.asarray(lab_score[note_indices].start_times)
+
+    global_offset = (onset_align - onset_score).mean()
+    global_offset = int(round(global_offset / 50000) * 50000)
+
+    # Apply offset correction only when there is a big gap
+    apply_offset_correction = np.abs(global_offset * 1e-7) > offset_correction_threshold
+    if apply_offset_correction:
+        print(f"{name}: Global offset (in sec): {global_offset * 1e-7}")
+        lab_score.start_times = list(np.asarray(lab_score.start_times) + global_offset)
+        lab_score.end_times = list(np.asarray(lab_score.end_times) + global_offset)
+        onset_score += global_offset
+
+    # Exclude large diff parts (probably a bug of musicxml or alignment though)
+    valid_note_indices = []
+    for idx, (a, b) in enumerate(zip(onset_align, onset_score)):
+        note_idx = note_indices[idx]
+        lag = np.abs(a - b) / 50000
+        if _is_silence(lab_score.contexts[note_idx]):
+            if lag >= timelag_allowed_range_rest[0] and lag <= timelag_allowed_range_rest[1]:
+                valid_note_indices.append(note_idx)
+        else:
+            if lag >= timelag_allowed_range[0] and lag <= timelag_allowed_range[1]:
+                valid_note_indices.append(note_idx)
+
+    if len(valid_note_indices) < len(note_indices):
+        D = len(note_indices) - len(valid_note_indices)
+        print(f"{name}: {D}/{len(note_indices)} time-lags are excluded.")
+
+    # Note onsets as labels
+    lab_align = lab_align[valid_note_indices]
+    lab_score = lab_score[valid_note_indices]
+
+    # Save lab files
+    lab_align_dst_path = join(lab_align_dst_dir, name)
+    with open(lab_align_dst_path, "w") as of:
+        of.write(str(lab_align))
+
+    lab_score_dst_path = join(lab_score_dst_dir, name)
+    with open(lab_score_dst_path, "w") as of:
+        of.write(str(lab_score))
+
+### Prepare data for duration models
+
+dst_dir = join(out_dir, "duration")
+lab_align_dst_dir  = join(dst_dir, "label_phone_align")
+
+for d in [lab_align_dst_dir]:
+    os.makedirs(d, exist_ok=True)
+
+print("Prepare data for duration models")
+full_lab_align_files = sorted(glob(join(full_align_dir, "*.lab")))
+for lab_align_path in full_lab_align_files:
+    name = basename(lab_align_path)
+
+    lab_align = hts.load(lab_align_path)
+
+    # Save lab file
+    lab_align_dst_path = join(lab_align_dst_dir, name)
+    with open(lab_align_dst_path, "w") as of:
+        of.write(str(lab_align))
+
+
+### Prepare data for acoustic models
+
+dst_dir = join(out_dir, "acoustic")
+wav_dst_dir  = join(dst_dir, "wav")
+lab_align_dst_dir  = join(dst_dir, "label_phone_align")
+lab_score_dst_dir  = join(dst_dir, "label_phone_score")
+
+for d in [wav_dst_dir, lab_align_dst_dir, lab_score_dst_dir]:
+    os.makedirs(d, exist_ok=True)
+
+print("Prepare data for acoustic models")
+full_lab_align_files = sorted(glob(join(full_align_dir, "*.lab")))
+for lab_align_path in full_lab_align_files:
+    name = splitext(basename(lab_align_path))[0]
+    lab_score_path = join(full_dir, name + ".lab")
+    assert exists(lab_score_path)
+    wav_path = join(hts_demo_root, "data", "wav", name + ".wav")
+    raw_path = join(hts_demo_root, "data", "raw", name + ".raw")
+
+    # We can load and manupulate audio (e.g., normalizing gain), but for now just copy it as is
+    if exists(wav_path):
+        # sr, wave = wavfile.read(wav_path)
+        wav, sr = librosa.load(wav_path, sr=48000)
+    else:
+        assert raw_path
+        wav = np.fromfile(raw_path, dtype=np.int16)
+        wav = wav.astype(np.float32) / 2**15
+        sr = 48000
+
+    if gain_normalize:
+        wav = wav / wav.max() * 0.99
+
+    lab_align = hts.load(lab_align_path)
+    lab_score = hts.load(lab_score_path)
+
+    # Save caudio
+    wav_dst_path = join(wav_dst_dir, name + ".wav")
+    # TODO: consider explicit subtype
+    sf.write(wav_dst_path, wav, sr)
+
+    # Save label
+    lab_align_dst_path = join(lab_align_dst_dir, name + ".lab")
+    with open(lab_align_dst_path, "w") as of:
+        of.write(str(lab_align))
+
+    lab_score_dst_path = join(lab_score_dst_dir, name + ".lab")
+    with open(lab_score_dst_path, "w") as of:
+        of.write(str(lab_score))
+
+sys.exit(0)

--- a/nnsvs/bin/conf/synthesis/config.yaml
+++ b/nnsvs/bin/conf/synthesis/config.yaml
@@ -39,8 +39,6 @@ timelag:
   in_scaler_path:
   out_scaler_path:
   model_yaml:
-  stream_sizes: [1]
-  has_dynamic_features: [false]
 
   allowed_range: [-20, 20] # in frames
   allowed_range_rest: [-40, 40]
@@ -51,8 +49,6 @@ duration:
   in_scaler_path:
   out_scaler_path:
   model_yaml:
-  stream_sizes: [1]
-  has_dynamic_features: [false]
 
 acoustic:
   question_path:
@@ -62,8 +58,5 @@ acoustic:
   model_yaml:
   subphone_features: coarse_coding
   # (mgc, lf0, vuv, bap)
-  stream_sizes: [180, 3, 1, 15]
-  has_dynamic_features: [true, true, false, true]
-  num_windows: 3
   relative_f0: true
   post_filter: true

--- a/nnsvs/bin/conf/train/model/acoustic.yaml
+++ b/nnsvs/bin/conf/train/model/acoustic.yaml
@@ -5,6 +5,7 @@ has_dynamic_features: [true, true, false, true]
 num_windows: 3
 # If None, automatically set based on stream sizes
 stream_weights:
+stream_wise_training: false
 
 netG:
   _target_: nnsvs.model.Conv1dResnet

--- a/nnsvs/bin/conf/train/model/duration.yaml
+++ b/nnsvs/bin/conf/train/model/duration.yaml
@@ -3,6 +3,7 @@
 stream_sizes: [1]
 has_dynamic_features: [false]
 stream_weights: [1]
+stream_wise_training: false
 
 netG:
   _target_: nnsvs.model.LSTMRNN

--- a/nnsvs/bin/conf/train/model/timelag.yaml
+++ b/nnsvs/bin/conf/train/model/timelag.yaml
@@ -3,6 +3,7 @@
 stream_sizes: [1]
 has_dynamic_features: [false]
 stream_weights: [1]
+stream_wise_training: false
 
 netG:
   _target_: nnsvs.model.FeedForwardNet

--- a/nnsvs/bin/generate.py
+++ b/nnsvs/bin/generate.py
@@ -22,6 +22,51 @@ logger = None
 
 use_cuda = torch.cuda.is_available()
 
+def generate(config, model, device, in_feats, scaler, out_dir):
+    with torch.no_grad():
+        for idx in tqdm(range(len(in_feats))):
+            feats = torch.from_numpy(in_feats[idx]).unsqueeze(0).to(device)
+
+            if config.stream_wise_training and \
+               type(model) is list and \
+               len(model) == len(config.stream_sizes):
+                # stream-wise trained model
+                out = []
+                for stream_id in range(len(config.stream_sizes)):
+                    out.append(model[stream_id](feats, [feats.shape[1]]).squeeze(0).cpu().data.numpy())
+                out = np.concatenate(out, -1)
+            else:
+                out = model(feats, [feats.shape[1]]).squeeze(0).cpu().data.numpy()
+            
+            out = scaler.inverse_transform(out)
+
+            # Apply MLPG if necessary
+            print(f"config.has_dynamic_features: {config.has_dynamic_features}")
+            if np.any(config.has_dynamic_features):
+                windows = get_windows(3)
+                out = multi_stream_mlpg(
+                    out, scaler.var_, windows, config.stream_sizes,
+                    config.has_dynamic_features)
+
+            name = basename(in_feats.collected_files[idx][0])
+            out_path = join(out_dir, name)
+            np.save(out_path, out, allow_pickle=False)
+
+
+def resume(config, device, checkpoint, stream_id=None):
+    if stream_id is not None and\
+       len(config.stream_sizes) == len(checkpoint):
+        model = hydra.utils.instantiate(config.models[stream_id].netG).to(device)
+        cp = torch.load(to_absolute_path(checkpoint[stream_id]),
+                        map_location=lambda storage, loc: storage)
+    else:
+        model = hydra.utils.instantiate(config.netG).to(device)
+        cp = torch.load(to_absolute_path(checkpoint),
+                        map_location=lambda storage, loc: storage)
+
+    model.load_state_dict(cp["state_dict"])
+
+    return model
 
 @hydra.main(config_path="conf/generate/config.yaml")
 def my_app(config : DictConfig) -> None:
@@ -35,34 +80,21 @@ def my_app(config : DictConfig) -> None:
     os.makedirs(out_dir, exist_ok=True)
 
     model_config = OmegaConf.load(to_absolute_path(config.model.model_yaml))
-    model = hydra.utils.instantiate(model_config.netG).to(device)
-    checkpoint = torch.load(to_absolute_path(config.model.checkpoint),
-        map_location=lambda storage, loc: storage)
-    model.load_state_dict(checkpoint["state_dict"])
 
     scaler = joblib.load(to_absolute_path(config.out_scaler_path))
-
     in_feats = FileSourceDataset(NpyFileSource(in_dir))
-
-    with torch.no_grad():
-        for idx in tqdm(range(len(in_feats))):
-            feats = torch.from_numpy(in_feats[idx]).unsqueeze(0).to(device)
-            out = model(feats, [feats.shape[1]]).squeeze(0).cpu().data.numpy()
-
-            out = scaler.inverse_transform(out)
-
-            # Apply MLPG if necessary
-            if np.any(model_config.has_dynamic_features):
-                windows = get_windows(3)
-                out = multi_stream_mlpg(
-                    out, scaler.var_, windows, model_config.stream_sizes,
-                    model_config.has_dynamic_features)
-
-            name = basename(in_feats.collected_files[idx][0])
-            out_path = join(out_dir, name)
-            np.save(out_path, out, allow_pickle=False)
-
-
+        
+    if model_config.stream_wise_training and \
+       len(model_config.models) == len(model_config.stream_sizes) and \
+       len(config.model.checkpoint) == len(model_config.stream_sizes):
+        model = []
+        for stream_id in range(len(model_config.stream_sizes)):
+            model.append(resume(model_config, device, config.model.checkpoint, stream_id))
+    else:
+        model = resume(model_config, device, config.model.checkpoint, None)
+        
+    generate(model_config, model, device, in_feats, scaler, out_dir)
+            
 def entry():
     my_app()
 

--- a/nnsvs/bin/synthesis.py
+++ b/nnsvs/bin/synthesis.py
@@ -20,9 +20,9 @@ logger = None
 
 
 def synthesis(config, device, label_path, question_path,
-        timelag_model, timelag_in_scaler, timelag_out_scaler,
-        duration_model, duration_in_scaler, duration_out_scaler,
-        acoustic_model, acoustic_in_scaler, acoustic_out_scaler):
+              timelag_model, timelag_config, timelag_in_scaler, timelag_out_scaler,
+              duration_model, duration_config, duration_in_scaler, duration_out_scaler,
+              acoustic_model, acoustic_config, acoustic_in_scaler, acoustic_out_scaler):
     # load labels and question
     labels = hts.load(label_path).round_()
     binary_dict, continuous_dict = hts.load_question_set(
@@ -40,34 +40,50 @@ def synthesis(config, device, label_path, question_path,
         duration_modified_labels = labels
     else:
         # Time-lag
-        lag = predict_timelag(device, labels, timelag_model, timelag_in_scaler,
-            timelag_out_scaler, binary_dict, continuous_dict, pitch_indices,
-            log_f0_conditioning, config.timelag.allowed_range)
+        lag = predict_timelag(device, labels, timelag_model, timelag_config,
+                              timelag_in_scaler, timelag_out_scaler, binary_dict,
+                              continuous_dict, pitch_indices, log_f0_conditioning,
+                              config.timelag.allowed_range)
 
         # Timelag predictions
-        durations = predict_duration(device, labels, duration_model,
-            duration_in_scaler, duration_out_scaler, lag, binary_dict, continuous_dict,
-            pitch_indices, log_f0_conditioning)
+        durations = predict_duration(device, labels, duration_model, duration_config,
+                                     duration_in_scaler, duration_out_scaler, lag, binary_dict,
+                                     continuous_dict, pitch_indices, log_f0_conditioning)
 
         # Normalize phoneme durations
         duration_modified_labels = postprocess_duration(labels, durations, lag)
 
     # Predict acoustic features
-    acoustic_features = predict_acoustic(device, duration_modified_labels, acoustic_model,
-        acoustic_in_scaler, acoustic_out_scaler, binary_dict, continuous_dict,
-        config.acoustic.subphone_features, pitch_indices, log_f0_conditioning)
+    acoustic_features = predict_acoustic(device, duration_modified_labels, acoustic_model, acoustic_config, 
+                                         acoustic_in_scaler, acoustic_out_scaler, binary_dict, continuous_dict,
+                                         config.acoustic.subphone_features, pitch_indices, log_f0_conditioning)
 
     # Waveform generation
     generated_waveform = gen_waveform(
         duration_modified_labels, acoustic_features, acoustic_out_scaler,
-        binary_dict, continuous_dict, config.acoustic.stream_sizes,
-        config.acoustic.has_dynamic_features,
+        binary_dict, continuous_dict, acoustic_config.stream_sizes,
+        acoustic_config.has_dynamic_features,
         config.acoustic.subphone_features, log_f0_conditioning,
-        pitch_idx, config.acoustic.num_windows,
+        pitch_idx, acoustic_config.num_windows,
         config.acoustic.post_filter, config.sample_rate, config.frame_period,
         config.acoustic.relative_f0)
 
     return generated_waveform
+
+def resume(config, device, checkpoint, stream_id=None):
+    if stream_id is not None and\
+       len(config.stream_sizes) == len(checkpoint):
+        model = hydra.utils.instantiate(config.models[stream_id].netG).to(device)
+        cp = torch.load(to_absolute_path(checkpoint[stream_id]),
+                        map_location=lambda storage, loc: storage)
+    else:
+        model = hydra.utils.instantiate(config.netG).to(device)
+        cp = torch.load(to_absolute_path(checkpoint),
+                        map_location=lambda storage, loc: storage)
+
+    model.load_state_dict(cp["state_dict"])
+
+    return model
 
 
 @hydra.main(config_path="conf/synthesis/config.yaml")
@@ -83,33 +99,51 @@ def my_app(config : DictConfig) -> None:
 
     # timelag
     timelag_config = OmegaConf.load(to_absolute_path(config.timelag.model_yaml))
-    timelag_model = hydra.utils.instantiate(timelag_config.netG).to(device)
-    checkpoint = torch.load(to_absolute_path(config.timelag.checkpoint),
-        map_location=lambda storage, loc: storage)
-    timelag_model.load_state_dict(checkpoint["state_dict"])
+    if timelag_config.stream_wise_training and \
+       len(timelag_config.models) == len(timelag_config.stream_sizes) and \
+       len(config.timelag.checkpoint) == len(timelag_config.stream_sizes):
+        timelag_model = []
+        for stream_id in range(len(timelag_config.stream_sizes)):
+            model = resume(timelag_config, device, config.timelag.checkpoint, stream_id)
+            timelag_model.append(model.eval())
+    else:
+        timelag_model = resume(timelag_config, device, config.timelag.checkpoint, None)
+        timelag_model.eval()
+
     timelag_in_scaler = joblib.load(to_absolute_path(config.timelag.in_scaler_path))
     timelag_out_scaler = joblib.load(to_absolute_path(config.timelag.out_scaler_path))
-    timelag_model.eval()
 
     # duration
     duration_config = OmegaConf.load(to_absolute_path(config.duration.model_yaml))
-    duration_model = hydra.utils.instantiate(duration_config.netG).to(device)
-    checkpoint = torch.load(to_absolute_path(config.duration.checkpoint),
-        map_location=lambda storage, loc: storage)
-    duration_model.load_state_dict(checkpoint["state_dict"])
+    if duration_config.stream_wise_training and \
+       len(duration_config.models) == len(duration_config.stream_sizes) and \
+       len(config.duration.checkpoint) == len(duration_config.stream_sizes):
+        duration_model = []
+        for stream_id in range(len(duration_config.stream_sizes)):
+            model = resume(duration_config, device, config.duration.checkpoint, stream_id)
+            duration_model.append(model.eval())
+    else:
+        duration_model = resume(duration_config, device, config.duration.checkpoint, None)
+        duration_model.eval()
+
     duration_in_scaler = joblib.load(to_absolute_path(config.duration.in_scaler_path))
     duration_out_scaler = joblib.load(to_absolute_path(config.duration.out_scaler_path))
-    duration_model.eval()
-
+        
     # acoustic model
     acoustic_config = OmegaConf.load(to_absolute_path(config.acoustic.model_yaml))
-    acoustic_model = hydra.utils.instantiate(acoustic_config.netG).to(device)
-    checkpoint = torch.load(to_absolute_path(config.acoustic.checkpoint),
-        map_location=lambda storage, loc: storage)
-    acoustic_model.load_state_dict(checkpoint["state_dict"])
+    if acoustic_config.stream_wise_training and \
+       len(acoustic_config.models) == len(acoustic_config.stream_sizes) and \
+       len(config.acoustic.checkpoint) == len(acoustic_config.stream_sizes):
+        acoustic_model = []
+        for stream_id in range(len(acoustic_config.stream_sizes)):
+            model = resume(acoustic_config, device, config.acoustic.checkpoint, stream_id)
+            acoustic_model.append(model.eval())
+    else:
+        acoustic_model = resume(acoustic_config, device, config.acoustic.checkpoint, None)
+        acoustic_model.eval()
+        
     acoustic_in_scaler = joblib.load(to_absolute_path(config.acoustic.in_scaler_path))
     acoustic_out_scaler = joblib.load(to_absolute_path(config.acoustic.out_scaler_path))
-    acoustic_model.eval()
 
     # Run synthesis for each utt.
     question_path = to_absolute_path(config.question_path)
@@ -128,9 +162,9 @@ def my_app(config : DictConfig) -> None:
                     raise RuntimeError(f"Label file does not exist: {label_path}")
 
                 wav = synthesis(config, device, label_path, question_path,
-                    timelag_model, timelag_in_scaler, timelag_out_scaler,
-                    duration_model, duration_in_scaler, duration_out_scaler,
-                    acoustic_model, acoustic_in_scaler, acoustic_out_scaler)
+                                timelag_model, timelag_config, timelag_in_scaler, timelag_out_scaler,
+                                duration_model, duration_config, duration_in_scaler, duration_out_scaler,
+                                acoustic_model, acoustic_config, acoustic_in_scaler, acoustic_out_scaler)
                 wav = wav / np.max(np.abs(wav)) * (2**15 - 1)
 
                 out_wav_path = join(out_dir, f"{utt_id}.wav")


### PR DESCRIPTION
Hello, I made sample implementation of stream-wise training.

 1. I added stream_wise_training flag to each nnsvs/bin/conf/train/model/*.yaml file. The models for each stream are defined as list. The checkpoints on stage 5 and stage 6 are defined as list whose length is equal to len(stream_sizes). For detail, please see egs/nit-song070/05-swt-world/run.sh.
 2. I removed stream_sizes, has_dynamic_features, etc from nnsvs/bin/conf/synthesis/config.yaml and changed to read them from the generated config files on stage 4, because their values should be equal to those used on training.

Please advise me to improve the quality.