### PR TITLE
synthesis: expose gain_normalize option

### DIFF
--- a/nnsvs/bin/conf/synthesis/config.yaml
+++ b/nnsvs/bin/conf/synthesis/config.yaml
@@ -33,6 +33,8 @@ log_f0_conditioning: true
 # if true, time-lag and duration models will not be used.
 ground_truth_duration: false
 
+gain_normalize: false
+
 timelag:
   question_path:
   checkpoint:
@@ -41,7 +43,7 @@ timelag:
   model_yaml:
   stream_sizes: [1]
   has_dynamic_features: [false]
-  
+
   allowed_range: [-20, 20] # in frames
   allowed_range_rest: [-40, 40]
 
@@ -53,7 +55,7 @@ duration:
   model_yaml:
   stream_sizes: [1]
   has_dynamic_features: [false]
-  
+
 acoustic:
   question_path:
   checkpoint:
@@ -64,6 +66,6 @@ acoustic:
   # (mgc, lf0, vuv, bap)
   stream_sizes: [180, 3, 1, 15]
   has_dynamic_features: [true, true, false, true]
-  num_windows: 3  
+  num_windows: 3
   relative_f0: true
   post_filter: true

--- a/nnsvs/bin/synthesis.py
+++ b/nnsvs/bin/synthesis.py
@@ -47,7 +47,7 @@ def synthesis(config, device, label_path, question_path,
             log_f0_conditioning, config.timelag.allowed_range)
 
         # Timelag predictions
-        durations = predict_duration(device, labels, duration_model, duration_config, 
+        durations = predict_duration(device, labels, duration_model, duration_config,
             duration_in_scaler, duration_out_scaler, lag, binary_dict, continuous_dict,
             pitch_indices, log_f0_conditioning)
 
@@ -133,7 +133,9 @@ def my_app(config : DictConfig) -> None:
                                 timelag_model, timelag_config, timelag_in_scaler, timelag_out_scaler,
                                 duration_model, duration_config, duration_in_scaler, duration_out_scaler,
                                 acoustic_model, acoustic_config, acoustic_in_scaler, acoustic_out_scaler)
-                wav = wav / np.max(np.abs(wav)) * (2**15 - 1)
+                wav = np.clip(wav, -32768, 32767)
+                if config.gain_normalize:
+                    wav = wav / np.max(np.abs(wav)) * 32767
 
                 out_wav_path = join(out_dir, f"{utt_id}.wav")
                 wavfile.write(out_wav_path, rate=config.sample_rate, data=wav.astype(np.int16))


### PR DESCRIPTION
and set it to false by default. Also, added clipping operation to avoid
outliers. This is particulary useful for preventing shallow AR models
to produce extraordinary gain in which IIR filters are used at inference
time.