### PR TITLE
Delete unnecessary variables from nnsvs/bin/conf/synthesis/config.yaml

### DIFF
--- a/nnsvs/bin/conf/synthesis/config.yaml
+++ b/nnsvs/bin/conf/synthesis/config.yaml
@@ -41,8 +41,6 @@ timelag:
   in_scaler_path:
   out_scaler_path:
   model_yaml:
-  stream_sizes: [1]
-  has_dynamic_features: [false]
 
   allowed_range: [-20, 20] # in frames
   allowed_range_rest: [-40, 40]
@@ -53,8 +51,6 @@ duration:
   in_scaler_path:
   out_scaler_path:
   model_yaml:
-  stream_sizes: [1]
-  has_dynamic_features: [false]
 
 acoustic:
   question_path:
@@ -64,8 +60,5 @@ acoustic:
   model_yaml:
   subphone_features: coarse_coding
   # (mgc, lf0, vuv, bap)
-  stream_sizes: [180, 3, 1, 15]
-  has_dynamic_features: [true, true, false, true]
-  num_windows: 3
   relative_f0: true
   post_filter: true


### PR DESCRIPTION
Because MDN implementation(#20) required to pass the config of each model to predict_{timelag,duration,acoustic} in nnsvs/gen.py for mplg, I changed to pass the configs generated on training to synthesis in nnsvs/bin/synthesis.py.  

It is  no longer necessary to set stream_sizes, has_dynamic_features, num_windows in nnsvs/bin/conf/synthesis/config.yaml because these values can be read from the generated configs.
