### PR TITLE
synthesis: allow users specify expdir and stats_dir

### DIFF
--- a/nnsvs/bin/conf/synthesis/config.yaml
+++ b/nnsvs/bin/conf/synthesis/config.yaml
@@ -27,7 +27,6 @@ out_dir:
 label_path:
 out_wav_path:
 
-
 sample_rate: 48000
 frame_period: 5
 question_path: path/to/qst.hed
@@ -38,3 +37,9 @@ log_f0_conditioning: true
 ground_truth_duration: false
 
 gain_normalize: false
+
+# If not empty, try to search statisics in the directory
+stats_dir:
+# If not empty, try to search models in the directory
+model_dir:
+model_checkpoint: latest.pth


### PR DESCRIPTION
instead of manually specifying all the necessary checkpoints and scalers.
This should simplify command line args when we run the synthesis command.

Before:
```
nnsvs-synthesis question_path=$PWD/../../_common/hed/jp_qst003_nnsvs.hed \
 timelag.checkpoint=./exp/kiritan/timelag/latest.pth \
 timelag.in_scaler_path=dump/kiritan/norm/in_timelag_scaler.joblib \
 timelag.out_scaler_path=dump/kiritan/norm/out_timelag_scaler.joblib \
 duration.checkpoint=./exp/kiritan/duration/latest.pth \
 duration.in_scaler_path=dump/kiritan/norm/in_duration_scaler.joblib \
 duration.out_scaler_path=dump/kiritan/norm/out_duration_scaler.joblib \
 acoustic.checkpoint=./exp/kiritan/acoustic/latest.pth \
 acoustic.in_scaler_path=dump/kiritan/norm/in_acoustic_scaler.joblib \
 acoustic.out_scaler_path=dump/kiritan/norm/out_acoustic_scaler.joblib \
 timelag.model_yaml=exp/kiritan/timelag/model.yaml \
 duration.model_yaml=exp/kiritan/duration/model.yaml \
 acoustic.model_yaml=exp/kiritan/acoustic/model.yaml \
 label_path=/path/to/your/favorite/label.lab \
 out_wav_path=output.wav
```

After:
```
nnsvs-synthesis question_path=$PWD/../../_common/hed/jp_qst001_nnsvs.hed \
 model_dir=$PWD/exp/yoko/ \
 stats_dir=$PWD/dump/yoko/norm/ label_path=/path/to/your/favorite/label.lab \
 out_wav_path=output.wav
```

The above *real* commands are taken from my zsh history.
