### PR TITLE
Dim-wise MDN: attempt to improve MDN-based models

### DIFF
--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/acoustic/data/myconfig.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/acoustic/data/myconfig.yaml
@@ -1,0 +1,16 @@
+# @package _group_
+
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 2
+batch_size: 2
+pin_memory: true

--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/acoustic/model/acoustic_baseline.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/acoustic/model/acoustic_baseline.yaml
@@ -1,0 +1,17 @@
+# @package _group_
+# (mgc, lf0, vuv, bap)
+stream_sizes: [180, 3, 1, 15]
+has_dynamic_features: [true, true, false, true]
+num_windows: 3
+# If None, automatically set based on stream sizes
+stream_weights:
+
+netG:
+  _target_: nnsvs.model.Conv1dResnetMDN
+  in_dim: 299
+  out_dim: 199
+  hidden_dim: 128
+  num_layers: 6
+  dropout: 0.1
+  num_gaussians: 4
+  dim_wise: false

--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/acoustic/model/acoustic_mdn.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/acoustic/model/acoustic_mdn.yaml
@@ -1,0 +1,17 @@
+# @package _group_
+# (mgc, lf0, vuv, bap)
+stream_sizes: [180, 3, 1, 15]
+has_dynamic_features: [true, true, false, true]
+num_windows: 3
+# If None, automatically set based on stream sizes
+stream_weights:
+
+netG:
+  _target_: nnsvs.model.Conv1dResnetMDN
+  in_dim: 299
+  out_dim: 199
+  hidden_dim: 128
+  num_layers: 6
+  dropout: 0.1
+  num_gaussians: 4
+  dim_wise: true

--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/acoustic/train/myconfig.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/acoustic/train/myconfig.yaml
@@ -1,0 +1,29 @@
+# @package _group_
+
+out_dir: exp
+nepochs: 200
+checkpoint_epoch_interval: 20
+
+stream_wise_loss: false
+use_detect_anomaly: true
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 50
+      gamma: 0.5
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/duration/data/myconfig.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/duration/data/myconfig.yaml
@@ -1,0 +1,16 @@
+# @package _group_
+
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 2
+batch_size: 2
+pin_memory: true

--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/duration/model/duration_mdn.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/duration/model/duration_mdn.yaml
@@ -1,0 +1,14 @@
+# @package _group_
+
+stream_sizes: [1]
+has_dynamic_features: [false]
+stream_weights: [1]
+
+netG:
+  _target_: nnsvs.model.MDN
+  in_dim: 295
+  out_dim: 1
+  hidden_dim: 1024
+  num_layers: 4
+  dropout: 0.5
+  num_gaussians: 4

--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/duration/train/myconfig.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/duration/train/myconfig.yaml
@@ -1,0 +1,29 @@
+# @package _group_
+
+out_dir: exp
+nepochs: 50
+checkpoint_epoch_interval: 20
+
+stream_wise_loss: false
+use_detect_anomaly: true
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/timelag/data/myconfig.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/timelag/data/myconfig.yaml
@@ -1,0 +1,16 @@
+# @package _group_
+
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 2
+batch_size: 2
+pin_memory: true

--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/timelag/model/timelag_mdn.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/timelag/model/timelag_mdn.yaml
@@ -1,0 +1,14 @@
+# @package _group_
+
+stream_sizes: [1]
+has_dynamic_features: [false]
+stream_weights: [1]
+
+netG:
+  _target_: nnsvs.model.MDN
+  in_dim: 295
+  out_dim: 1
+  hidden_dim: 1024
+  num_layers: 4
+  dropout: 0.5
+  num_gaussians: 4

--- a/egs/nit-song070/svs-world-conv-mdn/conf/train/timelag/train/myconfig.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/conf/train/timelag/train/myconfig.yaml
@@ -1,0 +1,29 @@
+# @package _group_
+
+out_dir: exp
+nepochs: 50
+checkpoint_epoch_interval: 20
+
+stream_wise_loss: false
+use_detect_anomaly: true
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/egs/nit-song070/svs-world-conv-mdn/config.yaml
+++ b/egs/nit-song070/svs-world-conv-mdn/config.yaml
@@ -1,0 +1,65 @@
+# General settings.
+spk: "yoko"
+
+# exp tag(for managing experiments)
+tag:
+
+###########################################################
+#                DATA PREPARATION SETTING                 #
+###########################################################
+
+# Directory of Unzipped singing voice database
+# PLEASE CHANGE THE PATH BASED ON YOUR ENVIRONMENT
+db_root: "downloads/HTS-demo_NIT-SONG070-F001"
+
+# Output directory
+out_dir: "./data"
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+
+# HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path: "../../_common/hed/jp_qst003_nnsvs.hed"
+
+timelag_features: defaults
+duration_features: defaults
+acoustic_features: static_deltadelta
+
+###########################################################
+#                TRAINING SETTING                         #
+###########################################################
+
+# Models
+# To customize, put your config or change ones in
+# conf/train/{timelag,duration,acoustic}/ and
+# specify the config name below
+# NOTE: *_model: model definition, *_train: general train configs,
+# *_data: data configs (e.g., batch size)
+
+timelag_model: timelag_mdn
+timelag_train: myconfig
+timelag_data: myconfig
+
+duration_model: duration_mdn
+duration_train: myconfig
+duration_data: myconfig
+
+acoustic_model: acoustic_mdn
+acoustic_train: myconfig
+acoustic_data: myconfig
+
+# Pretrained model dir (leave empty to disable)
+pretrained_expdir:
+
+###########################################################
+#                SYNTHESIS SETTING                        #
+###########################################################
+timelag_synthesis: defaults
+duration_synthesis: defaults
+acoustic_synthesis: defaults
+
+# latest.pth or best.pth
+timelag_eval_checkpoint: latest.pth
+duration_eval_checkpoint: latest.pth
+acoustic_eval_checkpoint: latest.pth

--- a/egs/nit-song070/svs-world-conv-mdn/local
+++ b/egs/nit-song070/svs-world-conv-mdn/local
@@ -1,0 +1,1 @@
+../svs-world-conv

--- a/egs/nit-song070/svs-world-conv-mdn/run.sh
+++ b/egs/nit-song070/svs-world-conv-mdn/run.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+function xrun () {
+    set -x
+    $@
+    set +x
+}
+
+script_dir=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
+NNSVS_ROOT=$script_dir/../../../
+NNSVS_COMMON_ROOT=$NNSVS_ROOT/egs/_common/spsvs
+. $NNSVS_ROOT/utils/yaml_parser.sh || exit 1;
+
+eval $(parse_yaml "./config.yaml" "")
+
+train_set="train_no_dev"
+dev_set="dev"
+eval_set="eval"
+datasets=($train_set $dev_set $eval_set)
+testsets=($dev_set $eval_set)
+
+dumpdir=dump
+
+dump_org_dir=$dumpdir/$spk/org
+dump_norm_dir=$dumpdir/$spk/norm
+
+stage=0
+stop_stage=0
+
+. $NNSVS_ROOT/utils/parse_options.sh || exit 1;
+
+# exp name
+if [ -z ${tag:=} ]; then
+    expname=${spk}
+else
+    expname=${spk}_${tag}
+fi
+expdir=exp/$expname
+
+if [ ${stage} -le -1 ] && [ ${stop_stage} -ge -1 ]; then
+    if [ ! -e downloads/HTS-demo_NIT-SONG070-F001 ]; then
+        echo "stage -1: Downloading data"
+        mkdir -p downloads
+        cd downloads
+        curl -LO http://hts.sp.nitech.ac.jp/archives/2.3/HTS-demo_NIT-SONG070-F001.tar.bz2
+        tar jxvf HTS-demo_NIT-SONG070-F001.tar.bz2
+	cd $script_dir
+    fi
+fi
+
+if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
+    echo "stage 0: Data preparation"
+    # the following three directories will be created
+    # 1) data/timelag 2) data/duration 3) data/acoustic
+    python local/data_prep.py $hts_demo_root ./data --gain-normalize
+
+    echo "train/dev/eval split"
+    mkdir -p data/list
+    find data/acoustic/ -type f -name "*.wav" -exec basename {} .wav \; \
+        | sort > data/list/utt_list.txt
+    grep _003 data/list/utt_list.txt > data/list/$eval_set.list
+    grep _004 data/list/utt_list.txt > data/list/$dev_set.list
+    grep -v _003 data/list/utt_list.txt | grep -v _004 > data/list/$train_set.list
+fi
+
+if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
+    echo "stage 1: Feature generation"
+    . $NNSVS_COMMON_ROOT/feature_generation.sh
+fi
+
+if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
+    echo "stage 2: Training time-lag model"
+    . $NNSVS_COMMON_ROOT/train_timelag.sh
+fi
+
+if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
+    echo "stage 3: Training duration model"
+    . $NNSVS_COMMON_ROOT/train_duration.sh
+fi
+
+if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
+    echo "stage 4: Training acoustic model"
+    . $NNSVS_COMMON_ROOT/train_acoustic.sh
+fi
+
+if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
+    echo "stage 5: Generate features from timelag/duration/acoustic models"
+    . $NNSVS_COMMON_ROOT/generate.sh
+fi
+
+if [ ${stage} -le 6 ] && [ ${stop_stage} -ge 6 ]; then
+    echo "stage 6: Synthesis waveforms"
+    . $NNSVS_COMMON_ROOT/synthesis.sh
+fi

--- a/nnsvs/bin/conf/train/config.yaml
+++ b/nnsvs/bin/conf/train/config.yaml
@@ -8,3 +8,4 @@ defaults:
   - data: defaults
 
 verbose: 100
+seed: 773

--- a/nnsvs/bin/generate.py
+++ b/nnsvs/bin/generate.py
@@ -52,11 +52,9 @@ def my_app(config : DictConfig) -> None:
 
             if model.prediction_type() == PredictionType.PROBABILISTIC:
 
-                log_pi, log_sigma, mu = model.inference(feats, [feats.shape[1]])
-                
+                max_mu, max_sigma = model.inference(feats, [feats.shape[1]])
+
                 if np.any(model_config.has_dynamic_features):
-                    max_sigma, max_mu = mdn_get_most_probable_sigma_and_mu(log_pi, log_sigma, mu)
-                   
                     # Apply denormalization
                     # (B, T, D_out) -> (T, D_out)
                     max_sigma_sq = max_sigma.squeeze(0).cpu().data.numpy() ** 2 * scaler.var_
@@ -68,8 +66,7 @@ def my_app(config : DictConfig) -> None:
 
                 else:
                     # (T, D_out)
-                    _, out = mdn_get_most_probable_sigma_and_mu(log_pi, log_sigma, mu)
-                    out = out.squeeze(0).cpu().data.numpy()
+                    out = max_mu.squeeze(0).cpu().data.numpy()
                     out = scaler.inverse_transform(out)
             else:
                 out = model.inference(feats, [feats.shape[1]]).squeeze(0).cpu().data.numpy()

--- a/nnsvs/bin/train.py
+++ b/nnsvs/bin/train.py
@@ -16,7 +16,7 @@ from torch.nn import functional as F
 from torch import optim
 from torch.backends import cudnn
 from nnmnkwii.datasets import FileDataSource, FileSourceDataset, MemoryCacheDataset
-from nnsvs.util import make_non_pad_mask
+from nnsvs.util import make_non_pad_mask, init_seed
 from nnsvs.multistream import split_streams
 from nnsvs.logger import getLogger
 from nnsvs.base import PredictionType
@@ -232,6 +232,9 @@ def my_app(config : DictConfig) -> None:
         cudnn.deterministic = config.train.cudnn.deterministic
         logger.info(f"cudnn.deterministic: {cudnn.deterministic}")
         logger.info(f"cudnn.benchmark: {cudnn.benchmark}")
+
+    logger.info(f"Random seed: {config.seed}")
+    init_seed(config.seed)
 
     device = torch.device("cuda" if use_cuda else "cpu")
 

--- a/nnsvs/bin/train.py
+++ b/nnsvs/bin/train.py
@@ -169,11 +169,12 @@ def train_loop(config, device, model, optimizer, lr_scheduler, data_loaders):
                 if model.prediction_type() == PredictionType.PROBABILISTIC:
                     pi, sigma, mu = model(x, sorted_lengths)
 
-                    # (B, max(T))
+                    # (B, max(T)) or (B, max(T), D_out)
                     mask = make_non_pad_mask(sorted_lengths).to(device)
+                    mask = mask.unsqueeze(-1) if len(pi.shape) == 4 else mask
                     # Compute loss and apply mask
-                    loss = mdn_loss(pi, sigma, mu, y, reduce=False).masked_select(mask).mean()
-
+                    loss = mdn_loss(pi, sigma, mu, y, reduce=False)
+                    loss = loss.masked_select(mask).mean()
                 else:
                     y_hat = model(x, sorted_lengths)
 

--- a/nnsvs/mdn.py
+++ b/nnsvs/mdn.py
@@ -70,7 +70,7 @@ class MDNLayer(nn.Module):
         return log_pi, log_sigma, mu
 
 
-def mdn_loss(log_pi, log_sigma, mu, target, log_pi_min=-20.0, log_sigma_min=-20.0, reduce=True):
+def mdn_loss(log_pi, log_sigma, mu, target, log_pi_min=-7.0, log_sigma_min=-9.0, reduce=True):
     """Calculates the error, given the MoG parameters and the target.
     The loss is the negative log likelihood of the data given the MoG
     parameters.

--- a/nnsvs/mdn.py
+++ b/nnsvs/mdn.py
@@ -4,11 +4,15 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 
+
 class MDNLayer(nn.Module):
     """ Mixture Density Network layer
 
     The input maps to the parameters of a Mixture of Gaussians (MoG) probability
     distribution, where each Gaussian has out_dim dimensions and diagonal covariance.
+    If dim_wise is True, features for each dimension are modeld by independent 1-D GMMs
+    instead of modeling jointly. This would workaround training difficulty
+    especially for high dimensional data.
 
     Implementation references:
     1. Mixture Density Networks by Mike Dusenberry https://mikedusenberry.com/mixture-density-networks
@@ -20,82 +24,114 @@ class MDNLayer(nn.Module):
         in_dim (int): the number of dimensions in the input
         out_dim (int): the number of dimensions in the output
         num_gaussians (int): the number of mixture component
-
+        dim_wise (bool): whether to model data for each dimension seperately
     """
-    def __init__(self, in_dim, out_dim, num_gaussians=30):
+    def __init__(self, in_dim, out_dim, num_gaussians=30, dim_wise=False):
         super(MDNLayer, self).__init__()
         self.in_dim = in_dim
         self.out_dim = out_dim
         self.num_gaussians = num_gaussians
+        self.dim_wise = dim_wise
 
-        self.log_pi = nn.Linear(in_dim, num_gaussians)
+        odim_log_pi = out_dim * num_gaussians if dim_wise else num_gaussians
+        self.log_pi = nn.Linear(in_dim, odim_log_pi)
+
         self.log_sigma = nn.Linear(in_dim, out_dim * num_gaussians)
         self.mu = nn.Linear(in_dim, out_dim * num_gaussians)
 
     def forward(self, minibatch):
-        """
+        """Forward for MDN
+
         Args:
-            minibatch (B, T, D_in): B is the batch size and T is data lengths of this batch,
+            minibatch (torch.Tensor): tensor of shape (B, T, D_in)
+                B is the batch size and T is data lengths of this batch,
                 and D_in is in_dim.
 
         Returns:
-            log_pi (B, T, G): Log of a multinomial distribution of the Gaussians.
-                G is num_gaussians and D_out is out_dim.
-            log_sigma (B, T, G, D_out): mean of each Gaussians
-            mu (B, T, G, D_out): the log of standard deviation of each Gaussians.
+            torch.Tensor: Tensor of shape (B, T, G) or (B, T, G, D_out)
+                Log of mixture weights. G is num_gaussians and D_out is out_dim.
+            torch.Tensor: Tensor of shape (B, T, G, D_out)
+                the log of standard deviation of each Gaussians.
+            torch.Tensor: Tensor of shape (B, T, G, D_out)
+                mean of each Gaussians
         """
-
-        log_pi = F.log_softmax(self.log_pi(minibatch), dim=2)
+        B = len(minibatch)
+        if self.dim_wise:
+            # (B, T, G, D_out)
+            log_pi = self.log_pi(minibatch).view(B, -1, self.num_gaussians, self.out_dim)
+            log_pi = F.log_softmax(log_pi, dim=2)
+        else:
+            # (B, T, G)
+            log_pi = F.log_softmax(self.log_pi(minibatch), dim=2)
         log_sigma = self.log_sigma(minibatch)
-        log_sigma = log_sigma.view(len(minibatch), -1, self.num_gaussians, self.out_dim)
+        log_sigma = log_sigma.view(B, -1, self.num_gaussians, self.out_dim)
         mu = self.mu(minibatch)
-        mu = mu.view(len(minibatch), -1, self.num_gaussians, self.out_dim)
+        mu = mu.view(B, -1, self.num_gaussians, self.out_dim)
         return log_pi, log_sigma, mu
 
-def mdn_loss(log_pi, log_sigma, mu, target, log_pi_min=-7.0, log_sigma_min=-7.0, log_prob_min=-7.0, reduce=True):
+
+def mdn_loss(log_pi, log_sigma, mu, target, log_pi_min=-20.0, log_sigma_min=-20.0, reduce=True):
     """Calculates the error, given the MoG parameters and the target.
     The loss is the negative log likelihood of the data given the MoG
     parameters.
 
     Args:
-        log_pi (B, T, G): The log of multinomial distribution of the Gaussians. B is the batch size,
+        log_pi (torch.Tensor): Tensor of shape (B, T, G) or (B, T, G, D_out)
+            The log of multinomial distribution of the Gaussians. B is the batch size,
             T is data length of this batch, and G is num_gaussians of class MDNLayer.
-        log_sigma (B, T , G ,D_out): The log standard deviation of the Gaussians. D_out is out_dim of class
+        log_sigma (torch.Tensor): Tensor of shape (B, T, G ,D_out)
+            The log standard deviation of the Gaussians. D_out is out_dim of class
             MDNLayer.
-        mu (B , T, G, D_out): The means of the Gaussians.
-        target (B, T, D_out): The target variables.
+        mu (torch.Tensor): Tensor of shape (B, T, G, D_out)
+            The means of the Gaussians.
+        target (torch.Tensor): Tensor of shape (B, T, D_out)
+            The target variables.
         log_pi_min (float): Minimum value of log_pi (for numerical stability)
         log_sigma_min (float): Minimum value of log_sigma (for numerical stability)
-        log_prob_min (float): Minimum value of torch.distributions.Normal.log_prob
         reduce: If True, the losses are averaged for each batch.
+
     Returns:
         loss (B) or (B, T): Negative Log Likelihood of Mixture Density Networks.
     """
+    dim_wise = len(log_pi.shape) == 4
 
     # Clip log_sigma and log_pi with log_clamp_min for numerical stability
     log_sigma = torch.clamp(log_sigma, min=log_sigma_min)
     log_pi = torch.clamp(log_pi, min=log_pi_min)
+
     # Expand the dim of target as (B, T, D_out) -> (B, T, 1, D_out) -> (B, T,G, D_out)
     target = target.unsqueeze(2).expand_as(log_sigma)
 
-    # Create gaussians with mean=mu and variance=torch.exp(log_sigma)^2
-    dist = torch.distributions.Normal(loc=mu, scale=torch.exp(log_sigma))
+    # Center target variables and clamp them within +/- 5SD for numerical stability.
+    centered_target = target - mu
+    scale = torch.exp(log_sigma)
+    edge = 5 * scale
+    centered_target = torch.where(centered_target > edge, edge, centered_target)
+    centered_target = torch.where(centered_target < -edge, -edge, centered_target)
 
+    # Create gaussians with mean=0 and variance=torch.exp(log_sigma)^2
+    dist = torch.distributions.Normal(loc=0, scale=scale)
+
+    log_prob = dist.log_prob(centered_target)
+
+    if dim_wise:
+        # (B, T, D_out. D_out)
+        loss = log_prob + log_pi
+    else:
+        # Here we assume that the covariance matrix of multivariate Gaussian distribution is diagonal
+        # to handle the mean and the variance in each dimension separately.
+        # (Reference: https://markusthill.github.io/gaussian-distribution-with-a-diagonal-covariance-matrix/)
+        # log pi(x)N(y|mu(x),sigma(x)) = log pi(x) + log N(y|mu(x),sigma(x))
+        # log N(y_1,y_2,...,y_{D_out}|mu(x),sigma(x)) = log N(y_1|mu(x),sigma(x))...N(y_{D_out}|mu(x),sigma(x))
+        #                                             = \sum_{i=1}^{D_out} log N(y_i|mu(x),sigma(x))
+        # (B, T, G, D_out) -> (B, T, G)
+        loss = torch.sum(log_prob, dim=3) + log_pi
+
+    # Calculate negative log likelihood.
     # Use torch.log_sum_exp instead of the combination of torch.sum and torch.log
     # (Reference: https://github.com/r9y9/nnsvs/pull/20#discussion_r495514563)
-
-    # Here we assume that the covariance matrix of multivariate Gaussian distribution is diagonal
-    # to handle the mean and the variance in each dimension separately.
-    # (Reference: https://markusthill.github.io/gaussian-distribution-with-a-diagonal-covariance-matrix/)
-    # log pi(x)N(y|mu(x),sigma(x)) = log pi(x) + log N(y|mu(x),sigma(x))
-    # log N(y_1,y_2,...,y_{D_out}|mu(x),sigma(x)) = log N(y_1|mu(x),sigma(x))...N(y_{D_out}|mu(x),sigma(x))
-    #                                             = \sum_{i=1}^{D_out} log N(y_i|mu(x),sigma(x))
-    # (B, T, G, D_out) -> (B, T, G)
-    log_prob = dist.log_prob(target)
-    log_prob = torch.clamp(log_prob, min=log_prob_min)
-    loss = torch.sum(log_prob, dim=3) + log_pi
-    # Calculate negative log likelihood.
-    # (B, T, G) -> (B, T)
+    # if dim_wise is True: (B, T, G, D_out) -> (B, T, D_out)
+    # else (B, T, G) -> (B, T)
     loss = -torch.logsumexp(loss, dim=2)
 
     if reduce:
@@ -107,6 +143,7 @@ def mdn_loss(log_pi, log_sigma, mu, target, log_pi_min=-7.0, log_sigma_min=-7.0,
         return loss
     return
 
+
 # from r9y9/wavenet_vocoder/wavenet_vocoder/mixture.py
 def to_one_hot(tensor, n, fill_with=1.):
     # we perform one hot encore with respect to the last axis
@@ -116,55 +153,70 @@ def to_one_hot(tensor, n, fill_with=1.):
     one_hot.scatter_(len(tensor.size()), tensor.unsqueeze(-1), fill_with)
     return one_hot
 
+
 def mdn_get_most_probable_sigma_and_mu(log_pi, log_sigma, mu):
-    """ Retrun the mean and standard deviation of the Gaussian component whose weight coefficient is
-    the largest as the most probable predictions.
+    """Return the mean and standard deviation of the Gaussian component
+    whose weight coefficient is the largest as the most probable predictions.
 
     Args:
-        log_pi (B, T, G): The log of multinomial distribution of the Gaussians.
+        log_pi (torch.Tensor): Tensor of shape (B, T, G) or (B, T, G, D_out)
+            The log of multinomial distribution of the Gaussians.
             B is the batch size, T is data length of this batch,
             G is num_gaussians of class MDNLayer.
-        log_sigma (B, T, G, D_out): The standard deviation of the Gaussians. D_out is out_dim of class
+        log_sigma (torch.Tensor): Tensor of shape (B, T, G, D_out)
+            The standard deviation of the Gaussians. D_out is out_dim of class
             MDNLayer.
-        mu (B, T, G, D_out): The means of the Gaussians. D_out is out_dim of class
-            MDNLayer.
+        mu (torch.Tensor): Tensor of shape (B, T, G, D_out)
+            The means of the Gaussians. D_out is out_dim of class MDNLayer.
     Returns:
-        sigma, mu (B, T, D_out), (B, T, D_out): the standard deviation and means of
-            the most probabble Gaussian component.
+        - torch.Tensor: Tensor of shape (B, T, D_out). The standardd deviations
+            of the most probable Gaussian component.
+        - torch.Tensor: Tensor of shape (B, T, D_out). Means of the Gaussians.
     """
-    batch_size, _, num_gaussians , out_dim = mu.shape
+    dim_wise = len(log_pi.shape) == 4
+    _, _, num_gaussians , _ = mu.shape
     # Get the indexes of the largest log_pi
-    _, max_component = torch.max(log_pi, dim=2) # (B, T)
+    _, max_component = torch.max(log_pi, dim=2) # (B, T) or (B, T, C_out)
 
     # Convert max_component to one_hot manner
-    # (B, T) -> (B, T, G)
+    # if dim_wise: (B, T, D_out) -> (B, T, D_out, G)
+    # else: (B, T) -> (B, T, G)
     one_hot = to_one_hot(max_component, num_gaussians)
 
-    # Expand the dim of one_hot as  (B, T, G) -> (B, T, G, d_out)
-    one_hot = one_hot.unsqueeze(3).expand_as(mu)
+    if dim_wise:
+        # (B, T, G, D_out)
+        one_hot = one_hot.transpose(2, 3)
+        assert one_hot.shape == mu.shape
+    else:
+        # Expand the dim of one_hot as  (B, T, G) -> (B, T, G, d_out)
+        one_hot = one_hot.unsqueeze(3).expand_as(mu)
 
-    # Multply one_hot and sum to get mean(mu) and standard deviation(sigma) of the Gaussians
-    # whose weight coefficient(log_pi) is the largest.
+    # Multiply one_hot and sum to get mean(mu) and standard deviation(sigma)
+    # of the Gaussians whose weight coefficient(log_pi) is the largest.
     #  (B, T, G, d_out) -> (B, T, d_out)
     max_mu = torch.sum(mu * one_hot, dim=2)
     max_sigma = torch.exp(torch.sum(log_sigma * one_hot, dim=2))
 
     return max_sigma, max_mu
 
+
 def mdn_get_sample(log_pi, log_sigma, mu):
-    """ Sample from mixture of the Gaussian component whose weight coefficient is the largest
-    as the most probable predictions.
+    """ Sample from mixture of the Gaussian component whose weight coefficient is
+    the largest as the most probable predictions.
 
     Args:
-        log_pi (B, T, G): The log of multinomial distribution of the Gaussians.
+        log_pi (torch.Tensor): Tensor of shape (B, T, G) or (B, T, G, D_out)
+            The log of multinomial distribution of the Gaussians.
             B is the batch size, T is data length of this batch,
             G is num_gaussians of class MDNLayer.
-        log_sigma (B, T, G, D_out): The log of standard deviation of the Gaussians.
+        log_sigma (torch.Tensor): Tensor of shape (B, T, G, D_out)
+            The log of standard deviation of the Gaussians.
             D_out is out_dim of class MDNLayer.
-        mu (B, T, G, D_out): The means of the Gaussians. D_out is out_dim of class
-            MDNLayer.
+        mu (torch.Tensor): Tensor of shape (B, T, G, D_out)
+            The means of the Gaussians. D_out is out_dim of class MDNLayer.
     Returns:
-        sample (B, T, D_out): Sample from mixture of the Gaussian component.
+        torch.Tensor: Tensor of shape (B, T, D_out)
+            Sample from the mixture of the Gaussian component.
     """
     max_sigma, max_mu = mdn_get_most_probable_sigma_and_mu(log_pi, log_sigma, mu)
 

--- a/nnsvs/mdn.py
+++ b/nnsvs/mdn.py
@@ -70,7 +70,7 @@ class MDNLayer(nn.Module):
         return log_pi, log_sigma, mu
 
 
-def mdn_loss(log_pi, log_sigma, mu, target, log_pi_min=-7.0, log_sigma_min=-9.0, reduce=True):
+def mdn_loss(log_pi, log_sigma, mu, target, log_pi_min=-7.0, log_sigma_min=-7.0, reduce=True):
     """Calculates the error, given the MoG parameters and the target.
     The loss is the negative log likelihood of the data given the MoG
     parameters.

--- a/nnsvs/model.py
+++ b/nnsvs/model.py
@@ -8,7 +8,7 @@ from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 from torch.nn.utils import weight_norm
 
 from nnsvs.base import BaseModel, PredictionType
-from nnsvs.mdn import MDNLayer
+from nnsvs.mdn import MDNLayer, mdn_get_most_probable_sigma_and_mu
 from nnsvs.dsp import TrTimeInvFIRFilter
 from nnsvs.multistream import split_streams
 
@@ -197,6 +197,11 @@ class RMDN(BaseModel):
         out = self.mdn(out)
         return out
 
+    def inference(self, x, lengths=None):
+        log_pi, log_sigma, mu = self.forward(x, lengths)
+        sigma, mu = mdn_get_most_probable_sigma_and_mu(log_pi, log_sigma, mu)
+        return mu, sigma
+
 
 class MDN(BaseModel):
     def __init__(self, in_dim, hidden_dim, out_dim, num_layers=1, dropout=0.0,
@@ -215,6 +220,11 @@ class MDN(BaseModel):
     def forward(self, x, lengths=None):
         return self.model(x)
 
+    def inference(self, x, lengths=None):
+        log_pi, log_sigma, mu = self.forward(x, lengths)
+        sigma, mu = mdn_get_most_probable_sigma_and_mu(log_pi, log_sigma, mu)
+        return mu, sigma
+
 
 class Conv1dResnetMDN(BaseModel):
     def __init__(self, in_dim, hidden_dim, out_dim, num_layers=4, dropout=0.0,
@@ -230,3 +240,8 @@ class Conv1dResnetMDN(BaseModel):
 
     def forward(self, x, lengths=None):
         return self.model(x)
+
+    def inference(self, x, lengths=None):
+        log_pi, log_sigma, mu = self.forward(x, lengths)
+        sigma, mu = mdn_get_most_probable_sigma_and_mu(log_pi, log_sigma, mu)
+        return mu, sigma

--- a/nnsvs/model.py
+++ b/nnsvs/model.py
@@ -175,7 +175,8 @@ class LSTMRNNSAR(LSTMRNN):
 
 
 class RMDN(BaseModel):
-    def __init__(self, in_dim, hidden_dim, out_dim, num_layers=1, bidirectional=True, dropout=0.0, num_gaussians=8):
+    def __init__(self, in_dim, hidden_dim, out_dim, num_layers=1, bidirectional=True,
+            dropout=0.0, num_gaussians=8, dim_wise=False):
         super(RMDN, self).__init__()
         self.linear = nn.Linear(in_dim, hidden_dim)
         self.relu = nn.ReLU()
@@ -183,7 +184,7 @@ class RMDN(BaseModel):
         self.lstm = nn.LSTM(hidden_dim, hidden_dim, num_layers,
                             bidirectional=bidirectional, batch_first=True,
                             dropout=dropout)
-        self.mdn = MDNLayer(self.num_direction*hidden_dim, out_dim, num_gaussians=num_gaussians)
+        self.mdn = MDNLayer(self.num_direction*hidden_dim, out_dim, num_gaussians, dim_wise)
 
     def prediction_type(self):
         return PredictionType.PROBABILISTIC
@@ -198,13 +199,14 @@ class RMDN(BaseModel):
 
 
 class MDN(BaseModel):
-    def __init__(self, in_dim, hidden_dim, out_dim, num_layers=1, dropout=0.0, num_gaussians=8):
+    def __init__(self, in_dim, hidden_dim, out_dim, num_layers=1, dropout=0.0,
+            num_gaussians=8, dim_wise=False):
         super(MDN, self).__init__()
         model = [nn.Linear(in_dim, hidden_dim), nn.ReLU()]
         if num_layers > 1:
             for _ in range(num_layers - 1):
                 model += [nn.Linear(hidden_dim, hidden_dim), nn.ReLU()]
-        model += [MDNLayer(hidden_dim, out_dim, num_gaussians=num_gaussians)]
+        model += [MDNLayer(hidden_dim, out_dim, num_gaussians, dim_wise)]
         self.model = nn.Sequential(*model)
 
     def prediction_type(self):
@@ -215,11 +217,12 @@ class MDN(BaseModel):
 
 
 class Conv1dResnetMDN(BaseModel):
-    def __init__(self, in_dim, hidden_dim, out_dim, num_layers=4, dropout=0.0, num_gaussians=8):
+    def __init__(self, in_dim, hidden_dim, out_dim, num_layers=4, dropout=0.0,
+            num_gaussians=8, dim_wise=False):
         super().__init__()
         model = [Conv1dResnet(in_dim, hidden_dim, hidden_dim, num_layers, dropout),
                  nn.ReLU(),
-                 MDNLayer(hidden_dim, out_dim, num_gaussians=num_gaussians)]
+                 MDNLayer(hidden_dim, out_dim, num_gaussians, dim_wise)]
         self.model = nn.Sequential(*model)
 
     def prediction_type(self):

--- a/nnsvs/model.py
+++ b/nnsvs/model.py
@@ -212,3 +212,18 @@ class MDN(BaseModel):
 
     def forward(self, x, lengths=None):
         return self.model(x)
+
+
+class Conv1dResnetMDN(BaseModel):
+    def __init__(self, in_dim, hidden_dim, out_dim, num_layers=4, dropout=0.0, num_gaussians=8):
+        super().__init__()
+        model = [Conv1dResnet(in_dim, hidden_dim, hidden_dim, num_layers, dropout),
+                 nn.ReLU(),
+                 MDNLayer(hidden_dim, out_dim, num_gaussians=num_gaussians)]
+        self.model = nn.Sequential(*model)
+
+    def prediction_type(self):
+        return PredictionType.PROBABILISTIC
+
+    def forward(self, x, lengths=None):
+        return self.model(x)

--- a/nnsvs/util.py
+++ b/nnsvs/util.py
@@ -6,6 +6,14 @@ import random
 
 # mask-related functions were adapted from https://github.com/espnet/espnet
 
+def init_seed(seed):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
 def make_pad_mask(lengths, xs=None, length_dim=-1, maxlen=None):
     """Make mask tensor containing indices of padded part.
     Args:


### PR DESCRIPTION
## What

Here's my attempt to improve MDN-based models using dimension-wise 1-D GMMs. 

As a bonus, I added several improvements to the MDN implementation following #39. Note that I haven't addressed the numerical stability problems yet.

## Motivation

I noticed that MDN samples tend to be over-smoothed (sometimes consonant sounds are not very clear) than those of MSE-loss based models. My hypothesis is that modeling high-dimensional data (199 in most recipes) with GMMs are difficult especially if the number of mixtures is large, even the diagonal covariance matrix is assumed. To alleviate the difficulty, I added an option to enable dimension-wise MDN. Instead of modeling joint distribution with 199-dim GMMs, it uses 1-D GMMs for each feature dimension separately, which I suppose is easier to train and converges to the better local opitma.

In the implementation, mixture weights are predicted for each feature dimension (shape `B x T x G x D_out` where B, T, G, and D_out are the batch size, number of frames, number of mixtures, number of output dimensions), while those are predicted for all features in the current MDN (shape `B x T x G`).

## Note

Note that I cannot find any papers that do the same thing as my approach so far. So I might be wrong. Maybe I just cannot find good parameters for the normal MDN.

As far as I know,

- [1] An autoregressive recurrent mixture density network for parametric speech synthesis https://www.semanticscholar.org/paper/An-autoregressive-recurrent-mixture-density-network-Wang-Takaki/7b6964a96afeb2d32c79d2891d9ddfb66d182be9
- [2] Robust TTS duration modeling using DNNs http://www.research.ed.ac.uk/portal/files/23618761/henter2016robust_final_1.pdf

use the same MDN formulation as in #20 by @taroushirani). So I believe the MDN implementation (#20) is correct. This is also supported by a similar loss curve (from the paper [1]):

![Screenshot from 2020-11-16 12-05-57](https://user-images.githubusercontent.com/1220272/99208564-245d3300-2804-11eb-81fd-691708d835be.png)

Note for Conv1dResnetMDN: increasing the number of epochs from 50 to 200 improved the perceptual quality.

## Results

- MDN https://soundcloud.com/r9y9/20201116-nit-song070-svs-world-conv-mdn-baseline-nitech-jp-song070-f001-003
- DIm-wise MDN: https://soundcloud.com/r9y9/20201116-nit-song070-svs-world-conv-mdn-dim-wise-mdn-nitech-jp-song070-f001-003

To reproduce, try the following recipe:

```
cd egs/nit-song070/svs-world-conv-mdn
```

### MDN

(Assuming data preparation is finished)
```
CUDA_VISIBLE_DEVICES=0 ./run.sh --stage 2 --stop-stage 6 --tag baseline --acoustic-model acoustic_baseline
```

### Dim-wise MDN

```
CUDA_VISIBLE_DEVICES=0 ./run.sh --stage 2 --stop-stage 6 --tag new-mdn --acoustic-model acoustic_mdn 
```

Based on my perceptual testing, dim-wise MDN is better than the normal MDN. In particular, /s/ sound is much clearer in dim-wise MDN.

@taroushirani What do you think of the new approach? Any comments are welcome! 

I confirmed the dim-wise MDN works good for NIT-song070 dataset but haven't tested the performance on other datasets. It would great if any of you could check the performance on your dataset and share the results with us.

ref #20 , #39 