### PR TITLE
Speed up prepare-features

### DIFF
--- a/nnsvs/bin/conf/prepare_features/config.yaml
+++ b/nnsvs/bin/conf/prepare_features/config.yaml
@@ -22,6 +22,10 @@ utt_list: path/to/list.txt
 
 out_dir: dump
 
+# Number of processes using ProcessPoolExecutor (1 <= max_workers <= 61)
+# If null, it will default to the number of processors on the machine.
+max_workers: null
+
 # question path used for timelag, duration and acoustic models
 question_path:
 

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -172,7 +172,7 @@ def my_app(config: DictConfig) -> None:
                 future.result()
 
     # Save features for duration model
-    if config.timelag.enabled:
+    if config.duration.enabled:
         logger.info("Duration linguistic feature dim: %s", str(in_duration[0].shape[1]))
         logger.info("Duration feature dim: %s", str(out_duration[0].shape[1]))
         with ProcessPoolExecutor(max_workers=config.max_workers) as executor:

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -191,7 +191,7 @@ def my_app(config: DictConfig) -> None:
                 future.result()
 
     # Save features for duration model
-    if config.timelag.enabled:
+    if config.acoustic.enabled:
         logger.info("Acoustic linguistic feature dim: %s", str(in_acoustic[0].shape[1]))
         logger.info("Acoustic feature dim: %s", str(out_acoustic[0][0].shape[1]))
         with ProcessPoolExecutor(max_workers=config.max_workers) as executor:

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -190,7 +190,7 @@ def my_app(config: DictConfig) -> None:
             for future in tqdm(futures):
                 future.result()
 
-    # Save features for duration model
+    # Save features for acoustic model
     if config.acoustic.enabled:
         logger.info("Acoustic linguistic feature dim: %s", str(in_acoustic[0].shape[1]))
         logger.info("Acoustic feature dim: %s", str(out_acoustic[0][0].shape[1]))

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -61,7 +61,6 @@ def _prepare_acoustic_feature(in_acoustic_root, out_acoustic_root,
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)
-    # logger.info(config.pretty())
     logger.info(OmegaConf.to_yaml(config))
 
     utt_list = to_absolute_path(config.utt_list)

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -1,29 +1,67 @@
 # coding: utf-8
+import os
+from os.path import basename, join, splitext
 
 import hydra
-from hydra.utils import to_absolute_path
-from omegaconf import DictConfig
 import numpy as np
-from os.path import join
-from tqdm import tqdm
-from os.path import basename, splitext, exists
-import os
-import sys
-
+from hydra.utils import to_absolute_path
 from nnmnkwii.datasets import FileSourceDataset
-
-from nnsvs.data import (
-    MusicalLinguisticSource, TimeLagFeatureSource,
-    DurationFeatureSource, WORLDAcousticSource)
+from nnsvs.data import (DurationFeatureSource, MusicalLinguisticSource,
+                        TimeLagFeatureSource, WORLDAcousticSource)
 from nnsvs.logger import getLogger
+from omegaconf import DictConfig, OmegaConf
+from tqdm import tqdm
+
 logger = None
 
 
+def _prepare_timelag_feature(in_timelag_root, out_timelag_root,
+                             in_timelag: FileSourceDataset,
+                             out_timelag: FileSourceDataset, idx: int) -> None:
+    """prepare timelag feature for one item of in_duration
+    """
+    x, y = in_timelag[idx], out_timelag[idx]
+    name = splitext(basename(in_timelag.collected_files[idx][0]))[0]
+    xpath = join(in_timelag_root, name + "-feats.npy")
+    ypath = join(out_timelag_root, name + "-feats.npy")
+    np.save(xpath, x, allow_pickle=False)
+    np.save(ypath, y, allow_pickle=False)
+
+
+def _prepare_duration_feature(in_duration_root, out_duration_root,
+                              in_duration: FileSourceDataset,
+                              out_duration: FileSourceDataset, idx: int) -> None:
+    """prepare duration feature for one item of in_duration
+    """
+    x, y = in_duration[idx], out_duration[idx]
+    name = splitext(basename(in_duration.collected_files[idx][0]))[0]
+    xpath = join(in_duration_root, name + "-feats.npy")
+    ypath = join(out_duration_root, name + "-feats.npy")
+    np.save(xpath, x, allow_pickle=False)
+    np.save(ypath, y, allow_pickle=False)
+
+
+def _prepare_acoustic_feature(in_acoustic_root, out_acoustic_root,
+                              in_acoustic: FileSourceDataset,
+                              out_acoustic: FileSourceDataset, idx: int) -> None:
+    """prepare acoustic feature for one item of in_acoustic
+    """
+    x, (y, wave) = in_acoustic[idx], out_acoustic[idx]
+    name = splitext(basename(in_acoustic.collected_files[idx][0]))[0]
+    xpath = join(in_acoustic_root, name + "-feats.npy")
+    ypath = join(out_acoustic_root, name + "-feats.npy")
+    wpath = join(out_acoustic_root, name + "-wave.npy")
+    np.save(xpath, x, allow_pickle=False)
+    np.save(ypath, y, allow_pickle=False)
+    np.save(wpath, wave, allow_pickle=False)
+
+
 @hydra.main(config_path="conf/prepare_features/config.yaml")
-def my_app(config : DictConfig) -> None:
+def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)
-    logger.info(config.pretty())
+    # logger.info(config.pretty())
+    logger.info(OmegaConf.to_yaml(config))
 
     utt_list = to_absolute_path(config.utt_list)
     out_dir = to_absolute_path(config.out_dir)
@@ -36,12 +74,16 @@ def my_app(config : DictConfig) -> None:
         question_path = config.timelag.question_path
     else:
         question_path = question_path_general
-    in_timelag_source = MusicalLinguisticSource(utt_list,
+
+    in_timelag_source = MusicalLinguisticSource(
+        utt_list,
         to_absolute_path(config.timelag.label_phone_score_dir),
-        add_frame_features=False, subphone_features=None,
+        add_frame_features=False,
+        subphone_features=None,
         question_path=question_path,
         log_f0_conditioning=config.log_f0_conditioning)
-    out_timelag_source = TimeLagFeatureSource(utt_list,
+    out_timelag_source = TimeLagFeatureSource(
+        utt_list,
         to_absolute_path(config.timelag.label_phone_score_dir),
         to_absolute_path(config.timelag.label_phone_align_dir))
 
@@ -55,13 +97,17 @@ def my_app(config : DictConfig) -> None:
         question_path = config.duration.question_path
     else:
         question_path = question_path_general
-    in_duration_source = MusicalLinguisticSource(utt_list,
+
+    in_duration_source = MusicalLinguisticSource(
+        utt_list,
         to_absolute_path(config.duration.label_dir),
-        add_frame_features=False, subphone_features=None,
+        add_frame_features=False,
+        subphone_features=None,
         question_path=question_path,
         log_f0_conditioning=config.log_f0_conditioning)
     out_duration_source = DurationFeatureSource(
-        utt_list, to_absolute_path(config.duration.label_dir))
+        utt_list,
+        to_absolute_path(config.duration.label_dir))
 
     in_duration = FileSourceDataset(in_duration_source)
     out_duration = FileSourceDataset(out_duration_source)
@@ -73,12 +119,17 @@ def my_app(config : DictConfig) -> None:
         question_path = config.acoustic.question_path
     else:
         question_path = question_path_general
-    in_acoustic_source = MusicalLinguisticSource(utt_list,
-        to_absolute_path(config.acoustic.label_dir), question_path,
-        add_frame_features=True, subphone_features=config.acoustic.subphone_features,
+    in_acoustic_source = MusicalLinguisticSource(
+        utt_list,
+        to_absolute_path(config.acoustic.label_dir),
+        question_path,
+        add_frame_features=True,
+        subphone_features=config.acoustic.subphone_features,
         log_f0_conditioning=config.log_f0_conditioning)
-    out_acoustic_source = WORLDAcousticSource(utt_list,
-        to_absolute_path(config.acoustic.wav_dir), to_absolute_path(config.acoustic.label_dir),
+    out_acoustic_source = WORLDAcousticSource(
+        utt_list,
+        to_absolute_path(config.acoustic.wav_dir),
+        to_absolute_path(config.acoustic.label_dir),
         question_path, use_harvest=config.acoustic.use_harvest,
         f0_ceil=config.acoustic.f0_ceil, f0_floor=config.acoustic.f0_floor,
         frame_period=config.acoustic.frame_period, mgc_order=config.acoustic.mgc_order,
@@ -96,7 +147,7 @@ def my_app(config : DictConfig) -> None:
     out_acoustic_root = join(out_dir, "out_acoustic")
 
     for d in [in_timelag_root, out_timelag_root, in_duration_root, out_duration_root,
-            in_acoustic_root, out_acoustic_root]:
+              in_acoustic_root, out_acoustic_root]:
         if not os.path.exists(d):
             logger.info("mkdirs: {}".format(d))
             os.makedirs(d)
@@ -105,39 +156,25 @@ def my_app(config : DictConfig) -> None:
     if config.timelag.enabled:
         logger.info("Timelag linguistic feature dim: {}".format(in_timelag[0].shape[1]))
         logger.info("Timelag feature dim: {}".format(out_timelag[0].shape[1]))
-        for idx in tqdm(range(len(in_timelag))):
-            x, y = in_timelag[idx], out_timelag[idx]
-            name = splitext(basename(in_timelag.collected_files[idx][0]))[0]
-            xpath = join(in_timelag_root, name + "-feats.npy")
-            ypath = join(out_timelag_root, name + "-feats.npy")
-            np.save(xpath, x, allow_pickle=False)
-            np.save(ypath, y, allow_pickle=False)
+        for idx, _ in enumerate(tqdm(in_timelag)):
+            _prepare_timelag_feature(in_timelag_root, out_timelag_root,
+                                     in_timelag, out_timelag, idx)
 
     # Save features for duration model
     if config.duration.enabled:
         logger.info("Duration linguistic feature dim: {}".format(in_duration[0].shape[1]))
         logger.info("Duration feature dim: {}".format(out_duration[0].shape[1]))
-        for idx in tqdm(range(len(in_duration))):
-            x, y = in_duration[idx], out_duration[idx]
-            name = splitext(basename(in_duration.collected_files[idx][0]))[0]
-            xpath = join(in_duration_root, name + "-feats.npy")
-            ypath = join(out_duration_root, name + "-feats.npy")
-            np.save(xpath, x, allow_pickle=False)
-            np.save(ypath, y, allow_pickle=False)
+        for idx, _ in enumerate(tqdm(in_duration)):
+            _prepare_duration_feature(in_duration_root, out_duration_root,
+                                      in_duration, out_duration, idx)
 
     # Save features for acoustic model
     if config.acoustic.enabled:
         logger.info("Acoustic linguistic feature dim: {}".format(in_acoustic[0].shape[1]))
         logger.info("Acoustic feature dim: {}".format(out_acoustic[0][0].shape[1]))
-        for idx in tqdm(range(len(in_acoustic))):
-            x, (y, wave) = in_acoustic[idx], out_acoustic[idx]
-            name = splitext(basename(in_acoustic.collected_files[idx][0]))[0]
-            xpath = join(in_acoustic_root, name + "-feats.npy")
-            ypath = join(out_acoustic_root, name + "-feats.npy")
-            wpath = join(out_acoustic_root, name + "-wave.npy")
-            np.save(xpath, x, allow_pickle=False)
-            np.save(ypath, y, allow_pickle=False)
-            np.save(wpath, wave, allow_pickle=False)
+        for idx, _ in enumerate(tqdm(in_acoustic)):
+            _prepare_acoustic_feature(in_acoustic_root, out_acoustic_root,
+                                      in_acoustic, out_acoustic, idx)
 
 
 def entry():


### PR DESCRIPTION
For a large singing-databese, preparing features can be the 1st or 2nd bottleneck in training. I made it faster (certified).

- Speed up prepare-features by multi-threading using `joblib.Parallel()`
- Use `logger.info(OmegaConf.to_yaml(config))` instead of `logger.info(config.pretty())` to avoid warnings
- Remove unused imports