### PR TITLE
Fixed the deprecated object instantiation of hydra 1.1 or later.

### DIFF
--- a/egs/_common/spsvs/feature_generation.sh
+++ b/egs/_common/spsvs/feature_generation.sh
@@ -26,7 +26,7 @@ for inout in "in" "out"; do
     do
         find $dump_org_dir/$train_set/${inout}_${typ} -name "*feats.npy" > train_list.txt
         scaler_path=$dump_org_dir/${inout}_${typ}_scaler.joblib
-        xrun nnsvs-fit-scaler list_path=train_list.txt scaler.class=$scaler_class \
+        xrun nnsvs-fit-scaler list_path=train_list.txt scaler._target_=$scaler_class \
             out_path=$scaler_path
         rm -f train_list.txt
         cp -v $scaler_path $dump_norm_dir/${inout}_${typ}_scaler.joblib

--- a/nnsvs/bin/conf/fit_scaler/config.yaml
+++ b/nnsvs/bin/conf/fit_scaler/config.yaml
@@ -2,8 +2,7 @@
 verbose: 100
 
 scaler:
-  class: sklearn.preprocessing.StandardScaler
-  params: {}
+  _target_: sklearn.preprocessing.StandardScaler
 
 list_path: list.txt
 out_path: scaler.joblib


### PR DESCRIPTION
Config key "class" is deprecated from hydra 1.0 and removed from hydra 1.1 or later.  This PR will enable us to use NNSVS with hydra 1.1.x.