### PR TITLE
Fix feature cliping at synthesis

### DIFF
--- a/nnsvs/bin/conf/synthesis/acoustic/defaults.yaml
+++ b/nnsvs/bin/conf/synthesis/acoustic/defaults.yaml
@@ -8,3 +8,12 @@ model_yaml:
 subphone_features: coarse_coding
 relative_f0: true
 post_filter: true
+
+# Clip input context features to the range in the training data.
+# NOTE: While this would prevent unstable behaviors for test data,
+# it will also cause the model not to generalize well.
+# For example, it will be difficult to generate correct notes that are
+# not included in the training data.
+# It is recommended to set to false, especially when you have enough data
+# and expect your model to generalize well.
+force_clip_input_features: true

--- a/nnsvs/bin/conf/synthesis/duration/defaults.yaml
+++ b/nnsvs/bin/conf/synthesis/duration/defaults.yaml
@@ -5,3 +5,12 @@ checkpoint:
 in_scaler_path:
 out_scaler_path:
 model_yaml:
+
+# Clip input context features to the range in the training data.
+# NOTE: While this would prevent unstable behaviors for test data,
+# it will also cause the model not to generalize well.
+# For example, it will be difficult to generate correct notes that are
+# not included in the training data.
+# It is recommended to set to false, especially when you have enough data
+# and expect your model to generalize well.
+force_clip_input_features: true

--- a/nnsvs/bin/conf/synthesis/timelag/defaults.yaml
+++ b/nnsvs/bin/conf/synthesis/timelag/defaults.yaml
@@ -8,3 +8,12 @@ model_yaml:
 
 allowed_range: [-20, 20] # in frames
 allowed_range_rest: [-40, 40]
+
+# Clip input context features to the range in the training data.
+# NOTE: While this would prevent unstable behaviors for test data,
+# it will also cause the model not to generalize well.
+# For example, it will be difficult to generate correct notes that are
+# not included in the training data.
+# It is recommended to set to false, especially when you have enough data
+# and expect your model to generalize well.
+force_clip_input_features: true

--- a/nnsvs/bin/synthesis.py
+++ b/nnsvs/bin/synthesis.py
@@ -98,6 +98,7 @@ def synthesis(
             pitch_indices,
             log_f0_conditioning,
             config.timelag.allowed_range,
+            config.timelag.allowed_range_rest,
         )
 
         # Timelag predictions

--- a/nnsvs/bin/synthesis.py
+++ b/nnsvs/bin/synthesis.py
@@ -81,6 +81,24 @@ def synthesis(
 
     log_f0_conditioning = config.log_f0_conditioning
 
+    # Clipping settings
+    # setting True by default for backward compatibility
+    timelag_clip_input_features = (
+        config.timelag.force_clip_input_features
+        if "force_clip_input_features" in config.timelag
+        else True
+    )
+    duration_clip_input_features = (
+        config.duration.force_clip_input_features
+        if "force_clip_input_features" in config.duration
+        else True
+    )
+    acoustic_clip_input_features = (
+        config.acoustic.force_clip_input_features
+        if "force_clip_input_features" in config.acoustic
+        else True
+    )
+
     if config.ground_truth_duration:
         # Use provided alignment
         duration_modified_labels = labels
@@ -99,9 +117,10 @@ def synthesis(
             log_f0_conditioning,
             config.timelag.allowed_range,
             config.timelag.allowed_range_rest,
+            timelag_clip_input_features,
         )
 
-        # Timelag predictions
+        # Duration predictions
         durations = predict_duration(
             device,
             labels,
@@ -114,6 +133,7 @@ def synthesis(
             continuous_dict,
             pitch_indices,
             log_f0_conditioning,
+            duration_clip_input_features,
         )
 
         # Normalize phoneme durations
@@ -132,6 +152,7 @@ def synthesis(
         config.acoustic.subphone_features,
         pitch_indices,
         log_f0_conditioning,
+        acoustic_clip_input_features,
     )
 
     # Waveform generation

--- a/nnsvs/gen.py
+++ b/nnsvs/gen.py
@@ -60,6 +60,7 @@ def predict_timelag(
     log_f0_conditioning=True,
     allowed_range=None,
     allowed_range_rest=None,
+    force_clip_input_features=False,
 ):
     if allowed_range is None:
         allowed_range = [-20, 20]
@@ -95,10 +96,15 @@ def predict_timelag(
     timelag_linguistic_features = timelag_in_scaler.transform(
         timelag_linguistic_features
     )
-    if isinstance(timelag_in_scaler, MinMaxScaler):
-        # clip to feature range
-        timelag_linguistic_features = np.clip(
-            timelag_linguistic_features,
+    if force_clip_input_features and isinstance(timelag_in_scaler, MinMaxScaler):
+        # clip to feature range (except for pitch-related features)
+        non_pitch_indices = [
+            idx
+            for idx in range(timelag_linguistic_features.shape[1])
+            if idx not in pitch_indices
+        ]
+        timelag_linguistic_features[:, non_pitch_indices] = np.clip(
+            timelag_linguistic_features[:, non_pitch_indices],
             timelag_in_scaler.feature_range[0],
             timelag_in_scaler.feature_range[1],
         )
@@ -242,6 +248,7 @@ def predict_duration(
     continuous_dict,
     pitch_indices=None,
     log_f0_conditioning=True,
+    force_clip_input_features=False,
 ):
     # Extract musical/linguistic features
     duration_linguistic_features = fe.linguistic_features(
@@ -263,10 +270,15 @@ def predict_duration(
     duration_linguistic_features = duration_in_scaler.transform(
         duration_linguistic_features
     )
-    if isinstance(duration_in_scaler, MinMaxScaler):
-        # clip to feature range
-        duration_linguistic_features = np.clip(
-            duration_linguistic_features,
+    if force_clip_input_features and isinstance(duration_in_scaler, MinMaxScaler):
+        # clip to feature range (except for pitch-related features)
+        non_pitch_indices = [
+            idx
+            for idx in range(duration_linguistic_features.shape[1])
+            if idx not in pitch_indices
+        ]
+        duration_linguistic_features[:, non_pitch_indices] = np.clip(
+            duration_linguistic_features[:, non_pitch_indices],
             duration_in_scaler.feature_range[0],
             duration_in_scaler.feature_range[1],
         )
@@ -336,6 +348,7 @@ def predict_acoustic(
     subphone_features="coarse_coding",
     pitch_indices=None,
     log_f0_conditioning=True,
+    force_clip_input_features=False,
 ):
 
     # Musical/linguistic features
@@ -356,10 +369,15 @@ def predict_acoustic(
 
     # Apply normalization
     linguistic_features = acoustic_in_scaler.transform(linguistic_features)
-    if isinstance(acoustic_in_scaler, MinMaxScaler):
-        # clip to feature range
-        linguistic_features = np.clip(
-            linguistic_features,
+    if force_clip_input_features and isinstance(acoustic_in_scaler, MinMaxScaler):
+        # clip to feature range (except for pitch-related features)
+        non_pitch_indices = [
+            idx
+            for idx in range(linguistic_features.shape[1])
+            if idx not in pitch_indices
+        ]
+        linguistic_features[:, non_pitch_indices] = np.clip(
+            linguistic_features[:, non_pitch_indices],
             acoustic_in_scaler.feature_range[0],
             acoustic_in_scaler.feature_range[1],
         )


### PR DESCRIPTION
this was causing models not to be able to generate note pitch that is
not included in training data. To mitigate the problem,

1) clipping is only applid except for pitch features
2) add a option to fully disable the clipping

it is recommended to disable clipping especiall if you have enough data
and expect your model generalize well on unseen data.