### PR TITLE
Change to output the config of train and train_resf0 to logger

### DIFF
--- a/nnsvs/train_util.py
+++ b/nnsvs/train_util.py
@@ -147,6 +147,7 @@ def setup(config, device):
             data loaders, tensorboard writer, and logger.
     """
     logger = getLogger(config.verbose)
+    logger.info(OmegaConf.to_yaml(config))
 
     logger.info(f"PyTorch version: {torch.__version__}")
 


### PR DESCRIPTION
From the commit of https://github.com/r9y9/nnsvs/commit/51677aba88497902409bc7636cd52d2e88fb8a0b nnsvs stops to output the configuration of train.py and tran_resf0.py. I think this information is very useful and better to be included to the log.