### PR TITLE
Compatibility updates (Hydra, PyTorch and Matplotlib)

### DIFF
--- a/nnsvs/bin/anasyn.py
+++ b/nnsvs/bin/anasyn.py
@@ -165,7 +165,11 @@ def post_process(wav, sample_rate):
     return wav
 
 
-@hydra.main(config_path="conf/synthesis", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/synthesis",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)

--- a/nnsvs/bin/anasyn.py
+++ b/nnsvs/bin/anasyn.py
@@ -164,11 +164,7 @@ def post_process(wav, sample_rate):
     return wav
 
 
-@hydra.main(
-    config_path="conf/synthesis",
-    config_name="config",
-    version_base="1.1"
-)
+@hydra.main(config_path="conf/synthesis", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)
@@ -228,8 +224,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/anasyn.py
+++ b/nnsvs/bin/anasyn.py
@@ -7,15 +7,16 @@ import pysptk
 import pyworld
 import torch
 from hydra.utils import to_absolute_path
+from omegaconf import DictConfig, OmegaConf
+from scipy.io import wavfile
+from tqdm.auto import tqdm
+
 from nnsvs.dsp import bandpass_filter
 from nnsvs.gen import gen_world_params
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_static_stream_sizes, split_streams
 from nnsvs.svs import load_vocoder
 from nnsvs.util import init_seed, load_utt_list
-from omegaconf import DictConfig, OmegaConf
-from scipy.io import wavfile
-from tqdm.auto import tqdm
 
 
 @torch.no_grad()
@@ -164,7 +165,7 @@ def post_process(wav, sample_rate):
     return wav
 
 
-@hydra.main(config_path="conf/synthesis", config_name="config")
+@hydra.main(config_path="conf/synthesis", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)

--- a/nnsvs/bin/anasyn.py
+++ b/nnsvs/bin/anasyn.py
@@ -7,16 +7,15 @@ import pysptk
 import pyworld
 import torch
 from hydra.utils import to_absolute_path
-from omegaconf import DictConfig, OmegaConf
-from scipy.io import wavfile
-from tqdm.auto import tqdm
-
 from nnsvs.dsp import bandpass_filter
 from nnsvs.gen import gen_world_params
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_static_stream_sizes, split_streams
 from nnsvs.svs import load_vocoder
 from nnsvs.util import init_seed, load_utt_list
+from omegaconf import DictConfig, OmegaConf
+from scipy.io import wavfile
+from tqdm.auto import tqdm
 
 
 @torch.no_grad()

--- a/nnsvs/bin/fit_scaler.py
+++ b/nnsvs/bin/fit_scaler.py
@@ -4,10 +4,9 @@ import hydra
 import joblib
 import numpy as np
 from hydra.utils import to_absolute_path
+from nnsvs.logger import getLogger
 from omegaconf import DictConfig, OmegaConf
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
-
-from nnsvs.logger import getLogger
 
 
 @hydra.main(

--- a/nnsvs/bin/fit_scaler.py
+++ b/nnsvs/bin/fit_scaler.py
@@ -10,7 +10,11 @@ from sklearn.preprocessing import MinMaxScaler, StandardScaler
 from nnsvs.logger import getLogger
 
 
-@hydra.main(config_path="conf/fit_scaler", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/fit_scaler",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     logger = getLogger(config.verbose)
     logger.info(OmegaConf.to_yaml(config))

--- a/nnsvs/bin/fit_scaler.py
+++ b/nnsvs/bin/fit_scaler.py
@@ -9,11 +9,7 @@ from omegaconf import DictConfig, OmegaConf
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
 
 
-@hydra.main(
-    config_path="conf/fit_scaler",
-    config_name="config",
-    version_base="1.1"
-)
+@hydra.main(config_path="conf/fit_scaler", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     logger = getLogger(config.verbose)
     logger.info(OmegaConf.to_yaml(config))
@@ -50,8 +46,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/fit_scaler.py
+++ b/nnsvs/bin/fit_scaler.py
@@ -4,12 +4,13 @@ import hydra
 import joblib
 import numpy as np
 from hydra.utils import to_absolute_path
-from nnsvs.logger import getLogger
 from omegaconf import DictConfig, OmegaConf
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
 
+from nnsvs.logger import getLogger
 
-@hydra.main(config_path="conf/fit_scaler", config_name="config")
+
+@hydra.main(config_path="conf/fit_scaler", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     logger = getLogger(config.verbose)
     logger.info(OmegaConf.to_yaml(config))

--- a/nnsvs/bin/gen_static_features.py
+++ b/nnsvs/bin/gen_static_features.py
@@ -106,7 +106,11 @@ def _gen_static_features(
     return out_feats.astype(np.float32)
 
 
-@hydra.main(config_path="conf/gen_static_features", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/gen_static_features",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)

--- a/nnsvs/bin/gen_static_features.py
+++ b/nnsvs/bin/gen_static_features.py
@@ -8,7 +8,7 @@ import pyworld
 import torch
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from nnsvs.acoustic_models.util import pad_inference
 from nnsvs.base import PredictionType

--- a/nnsvs/bin/gen_static_features.py
+++ b/nnsvs/bin/gen_static_features.py
@@ -7,6 +7,9 @@ import numpy as np
 import pyworld
 import torch
 from hydra.utils import to_absolute_path
+from omegaconf import DictConfig, OmegaConf
+from tqdm import tqdm
+
 from nnsvs.acoustic_models.util import pad_inference
 from nnsvs.base import PredictionType
 from nnsvs.gen import get_windows
@@ -20,8 +23,6 @@ from nnsvs.multistream import (
 )
 from nnsvs.postfilters import variance_scaling
 from nnsvs.util import StandardScaler, load_utt_list
-from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
 
 logger = None
 
@@ -105,7 +106,7 @@ def _gen_static_features(
     return out_feats.astype(np.float32)
 
 
-@hydra.main(config_path="conf/gen_static_features", config_name="config")
+@hydra.main(config_path="conf/gen_static_features", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)
@@ -126,6 +127,7 @@ def my_app(config: DictConfig) -> None:
     checkpoint = torch.load(
         to_absolute_path(config.model.checkpoint),
         map_location=lambda storage, loc: storage,
+        weights_only=False,
     )
     model.load_state_dict(checkpoint["state_dict"])
     model.eval()
@@ -233,8 +235,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter
 
 
 if __name__ == "__main__":
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter

--- a/nnsvs/bin/gen_static_features.py
+++ b/nnsvs/bin/gen_static_features.py
@@ -106,9 +106,7 @@ def _gen_static_features(
 
 
 @hydra.main(
-    config_path="conf/gen_static_features",
-    config_name="config",
-    version_base="1.1"
+    config_path="conf/gen_static_features", config_name="config", version_base="1.1"
 )
 def my_app(config: DictConfig) -> None:
     global logger
@@ -238,8 +236,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/gen_static_features.py
+++ b/nnsvs/bin/gen_static_features.py
@@ -7,9 +7,6 @@ import numpy as np
 import pyworld
 import torch
 from hydra.utils import to_absolute_path
-from omegaconf import DictConfig, OmegaConf
-from tqdm.auto import tqdm
-
 from nnsvs.acoustic_models.util import pad_inference
 from nnsvs.base import PredictionType
 from nnsvs.gen import get_windows
@@ -23,6 +20,8 @@ from nnsvs.multistream import (
 )
 from nnsvs.postfilters import variance_scaling
 from nnsvs.util import StandardScaler, load_utt_list
+from omegaconf import DictConfig, OmegaConf
+from tqdm.auto import tqdm
 
 logger = None
 

--- a/nnsvs/bin/generate.py
+++ b/nnsvs/bin/generate.py
@@ -9,13 +9,12 @@ import numpy as np
 import torch
 from hydra.utils import to_absolute_path
 from nnmnkwii.datasets import FileSourceDataset
-from omegaconf import DictConfig, OmegaConf
-from tqdm.auto import tqdm
-
 from nnsvs.base import PredictionType
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_windows, multi_stream_mlpg
 from nnsvs.train_util import NpyFileSource
+from omegaconf import DictConfig, OmegaConf
+from tqdm.auto import tqdm
 
 logger = None
 

--- a/nnsvs/bin/generate.py
+++ b/nnsvs/bin/generate.py
@@ -10,7 +10,7 @@ import torch
 from hydra.utils import to_absolute_path
 from nnmnkwii.datasets import FileSourceDataset
 from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from nnsvs.base import PredictionType
 from nnsvs.logger import getLogger

--- a/nnsvs/bin/generate.py
+++ b/nnsvs/bin/generate.py
@@ -22,7 +22,11 @@ logger = None
 use_cuda = torch.cuda.is_available()
 
 
-@hydra.main(config_path="conf/generate", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/generate",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)

--- a/nnsvs/bin/generate.py
+++ b/nnsvs/bin/generate.py
@@ -21,11 +21,7 @@ logger = None
 use_cuda = torch.cuda.is_available()
 
 
-@hydra.main(
-    config_path="conf/generate",
-    config_name="config",
-    version_base="1.1"
-)
+@hydra.main(config_path="conf/generate", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)
@@ -54,7 +50,6 @@ def my_app(config: DictConfig) -> None:
             feats = torch.from_numpy(in_feats[idx]).unsqueeze(0).to(device)
 
             if model.prediction_type() == PredictionType.PROBABILISTIC:
-
                 max_mu, max_sigma = model.inference(feats, [feats.shape[1]])
 
                 if np.any(model_config.has_dynamic_features):
@@ -105,8 +100,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/generate.py
+++ b/nnsvs/bin/generate.py
@@ -9,19 +9,20 @@ import numpy as np
 import torch
 from hydra.utils import to_absolute_path
 from nnmnkwii.datasets import FileSourceDataset
+from omegaconf import DictConfig, OmegaConf
+from tqdm import tqdm
+
 from nnsvs.base import PredictionType
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_windows, multi_stream_mlpg
 from nnsvs.train_util import NpyFileSource
-from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
 
 logger = None
 
 use_cuda = torch.cuda.is_available()
 
 
-@hydra.main(config_path="conf/generate", config_name="config")
+@hydra.main(config_path="conf/generate", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)
@@ -101,8 +102,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter
 
 
 if __name__ == "__main__":
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -7,6 +7,9 @@ import hydra
 import numpy as np
 from hydra.utils import to_absolute_path
 from nnmnkwii.datasets import FileSourceDataset
+from omegaconf import DictConfig, OmegaConf
+from tqdm import tqdm
+
 from nnsvs.data import (
     DurationFeatureSource,
     MelF0AcousticSource,
@@ -15,8 +18,6 @@ from nnsvs.data import (
     WORLDAcousticSource,
 )
 from nnsvs.logger import getLogger
-from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
 
 logger = None
 
@@ -77,7 +78,7 @@ def _prepare_acoustic_feature(
     np.save(pfpath, y_pf, allow_pickle=False)
 
 
-@hydra.main(config_path="conf/prepare_features", config_name="config")
+@hydra.main(config_path="conf/prepare_features", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -7,9 +7,6 @@ import hydra
 import numpy as np
 from hydra.utils import to_absolute_path
 from nnmnkwii.datasets import FileSourceDataset
-from omegaconf import DictConfig, OmegaConf
-from tqdm.auto import tqdm
-
 from nnsvs.data import (
     DurationFeatureSource,
     MelF0AcousticSource,
@@ -18,6 +15,8 @@ from nnsvs.data import (
     WORLDAcousticSource,
 )
 from nnsvs.logger import getLogger
+from omegaconf import DictConfig, OmegaConf
+from tqdm.auto import tqdm
 
 logger = None
 

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -8,7 +8,7 @@ import numpy as np
 from hydra.utils import to_absolute_path
 from nnmnkwii.datasets import FileSourceDataset
 from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from nnsvs.data import (
     DurationFeatureSource,
@@ -78,7 +78,11 @@ def _prepare_acoustic_feature(
     np.save(pfpath, y_pf, allow_pickle=False)
 
 
-@hydra.main(config_path="conf/prepare_features", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/prepare_features",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -78,9 +78,7 @@ def _prepare_acoustic_feature(
 
 
 @hydra.main(
-    config_path="conf/prepare_features",
-    config_name="config",
-    version_base="1.1"
+    config_path="conf/prepare_features", config_name="config", version_base="1.1"
 )
 def my_app(config: DictConfig) -> None:
     global logger
@@ -298,8 +296,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/prepare_static_features.py
+++ b/nnsvs/bin/prepare_static_features.py
@@ -1,5 +1,5 @@
-"""Prepare static features from static + dynamic features
-"""
+"""Prepare static features from static + dynamic features"""
+
 import os
 from concurrent.futures import ProcessPoolExecutor
 from os.path import join
@@ -56,9 +56,7 @@ def _extract_static_features(
 
 
 @hydra.main(
-    config_path="conf/prepare_static_features",
-    config_name="config",
-    version_base="1.1"
+    config_path="conf/prepare_static_features", config_name="config", version_base="1.1"
 )
 def my_app(config: DictConfig) -> None:
     logger = getLogger(config.verbose)
@@ -99,8 +97,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/prepare_static_features.py
+++ b/nnsvs/bin/prepare_static_features.py
@@ -9,7 +9,7 @@ import numpy as np
 import pyworld
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_static_features

--- a/nnsvs/bin/prepare_static_features.py
+++ b/nnsvs/bin/prepare_static_features.py
@@ -8,12 +8,11 @@ import hydra
 import numpy as np
 import pyworld
 from hydra.utils import to_absolute_path
-from omegaconf import DictConfig, OmegaConf
-from tqdm.auto import tqdm
-
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_static_features
 from nnsvs.util import get_world_stream_info, load_utt_list
+from omegaconf import DictConfig, OmegaConf
+from tqdm.auto import tqdm
 
 
 def _extract_static_features(

--- a/nnsvs/bin/prepare_static_features.py
+++ b/nnsvs/bin/prepare_static_features.py
@@ -8,11 +8,12 @@ import hydra
 import numpy as np
 import pyworld
 from hydra.utils import to_absolute_path
+from omegaconf import DictConfig, OmegaConf
+from tqdm import tqdm
+
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_static_features
 from nnsvs.util import get_world_stream_info, load_utt_list
-from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
 
 
 def _extract_static_features(
@@ -55,7 +56,7 @@ def _extract_static_features(
     np.save(static_path, static_feats, allow_pickle=False)
 
 
-@hydra.main(config_path="conf/prepare_static_features", config_name="config")
+@hydra.main(config_path="conf/prepare_static_features", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     logger = getLogger(config.verbose)
     logger.info(OmegaConf.to_yaml(config))

--- a/nnsvs/bin/prepare_static_features.py
+++ b/nnsvs/bin/prepare_static_features.py
@@ -56,7 +56,11 @@ def _extract_static_features(
     np.save(static_path, static_feats, allow_pickle=False)
 
 
-@hydra.main(config_path="conf/prepare_static_features", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/prepare_static_features",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     logger = getLogger(config.verbose)
     logger.info(OmegaConf.to_yaml(config))

--- a/nnsvs/bin/prepare_voc_features.py
+++ b/nnsvs/bin/prepare_voc_features.py
@@ -8,7 +8,7 @@ import hydra
 import numpy as np
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_static_features

--- a/nnsvs/bin/prepare_voc_features.py
+++ b/nnsvs/bin/prepare_voc_features.py
@@ -7,11 +7,12 @@ from os.path import exists, islink, join
 import hydra
 import numpy as np
 from hydra.utils import to_absolute_path
+from omegaconf import DictConfig, OmegaConf
+from tqdm import tqdm
+
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_static_features
 from nnsvs.util import get_world_stream_info, load_utt_list
-from omegaconf import DictConfig, OmegaConf
-from tqdm import tqdm
 
 
 def _prepare_voc_features(
@@ -55,7 +56,7 @@ def _prepare_voc_features(
         os.symlink(join(in_dir, utt_id + "-wave.npy"), save_wave_path)
 
 
-@hydra.main(config_path="conf/prepare_static_features", config_name="config")
+@hydra.main(config_path="conf/prepare_static_features", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     logger = getLogger(config.verbose)
     logger.info(OmegaConf.to_yaml(config))

--- a/nnsvs/bin/prepare_voc_features.py
+++ b/nnsvs/bin/prepare_voc_features.py
@@ -7,12 +7,11 @@ from os.path import exists, islink, join
 import hydra
 import numpy as np
 from hydra.utils import to_absolute_path
-from omegaconf import DictConfig, OmegaConf
-from tqdm.auto import tqdm
-
 from nnsvs.logger import getLogger
 from nnsvs.multistream import get_static_features
 from nnsvs.util import get_world_stream_info, load_utt_list
+from omegaconf import DictConfig, OmegaConf
+from tqdm.auto import tqdm
 
 
 def _prepare_voc_features(

--- a/nnsvs/bin/prepare_voc_features.py
+++ b/nnsvs/bin/prepare_voc_features.py
@@ -56,7 +56,11 @@ def _prepare_voc_features(
         os.symlink(join(in_dir, utt_id + "-wave.npy"), save_wave_path)
 
 
-@hydra.main(config_path="conf/prepare_static_features", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/prepare_static_features",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     logger = getLogger(config.verbose)
     logger.info(OmegaConf.to_yaml(config))

--- a/nnsvs/bin/prepare_voc_features.py
+++ b/nnsvs/bin/prepare_voc_features.py
@@ -1,5 +1,5 @@
-"""Prepare input features for training neural vocoders
-"""
+"""Prepare input features for training neural vocoders"""
+
 import os
 from concurrent.futures import ProcessPoolExecutor
 from os.path import exists, islink, join
@@ -56,9 +56,7 @@ def _prepare_voc_features(
 
 
 @hydra.main(
-    config_path="conf/prepare_static_features",
-    config_name="config",
-    version_base="1.1"
+    config_path="conf/prepare_static_features", config_name="config", version_base="1.1"
 )
 def my_app(config: DictConfig) -> None:
     logger = getLogger(config.verbose)
@@ -106,8 +104,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/preprocess_normalize.py
+++ b/nnsvs/bin/preprocess_normalize.py
@@ -13,7 +13,7 @@ import numpy as np
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, OmegaConf
 from sklearn.preprocessing import StandardScaler
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from nnsvs.logger import getLogger
 

--- a/nnsvs/bin/preprocess_normalize.py
+++ b/nnsvs/bin/preprocess_normalize.py
@@ -76,9 +76,7 @@ def apply_normalization_dir2dir(
 
 
 @hydra.main(
-    config_path="conf/preprocess_normalize",
-    config_name="config",
-    version_base="1.1"
+    config_path="conf/preprocess_normalize", config_name="config", version_base="1.1"
 )
 def my_app(config: DictConfig) -> None:
     global logger
@@ -104,4 +102,4 @@ def entry():
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/preprocess_normalize.py
+++ b/nnsvs/bin/preprocess_normalize.py
@@ -76,7 +76,11 @@ def apply_normalization_dir2dir(
         future.result()
 
 
-@hydra.main(config_path="conf/preprocess_normalize", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/preprocess_normalize",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)

--- a/nnsvs/bin/preprocess_normalize.py
+++ b/nnsvs/bin/preprocess_normalize.py
@@ -11,11 +11,10 @@ import hydra
 import joblib
 import numpy as np
 from hydra.utils import to_absolute_path
+from nnsvs.logger import getLogger
 from omegaconf import DictConfig, OmegaConf
 from sklearn.preprocessing import StandardScaler
 from tqdm.auto import tqdm
-
-from nnsvs.logger import getLogger
 
 logger = None
 

--- a/nnsvs/bin/preprocess_normalize.py
+++ b/nnsvs/bin/preprocess_normalize.py
@@ -11,10 +11,11 @@ import hydra
 import joblib
 import numpy as np
 from hydra.utils import to_absolute_path
-from nnsvs.logger import getLogger
 from omegaconf import DictConfig, OmegaConf
 from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
+
+from nnsvs.logger import getLogger
 
 logger = None
 
@@ -75,7 +76,7 @@ def apply_normalization_dir2dir(
         future.result()
 
 
-@hydra.main(config_path="conf/preprocess_normalize", config_name="config")
+@hydra.main(config_path="conf/preprocess_normalize", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)
@@ -100,4 +101,4 @@ def entry():
 
 
 if __name__ == "__main__":
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter

--- a/nnsvs/bin/synthesis.py
+++ b/nnsvs/bin/synthesis.py
@@ -7,10 +7,6 @@ import numpy as np
 import torch
 from hydra.utils import to_absolute_path
 from nnmnkwii.io import hts
-from omegaconf import DictConfig, OmegaConf
-from scipy.io import wavfile
-from tqdm.auto import tqdm
-
 from nnsvs.gen import (
     postprocess_acoustic,
     postprocess_waveform,
@@ -20,6 +16,9 @@ from nnsvs.gen import (
 )
 from nnsvs.logger import getLogger
 from nnsvs.util import extract_static_scaler, init_seed, load_utt_list, load_vocoder
+from omegaconf import DictConfig, OmegaConf
+from scipy.io import wavfile
+from tqdm.auto import tqdm
 
 
 @hydra.main(

--- a/nnsvs/bin/synthesis.py
+++ b/nnsvs/bin/synthesis.py
@@ -22,7 +22,11 @@ from nnsvs.logger import getLogger
 from nnsvs.util import extract_static_scaler, init_seed, load_utt_list, load_vocoder
 
 
-@hydra.main(config_path="conf/synthesis", config_name="config")
+@hydra.main(
+    config_path="conf/synthesis",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)

--- a/nnsvs/bin/synthesis.py
+++ b/nnsvs/bin/synthesis.py
@@ -21,11 +21,7 @@ from scipy.io import wavfile
 from tqdm.auto import tqdm
 
 
-@hydra.main(
-    config_path="conf/synthesis",
-    config_name="config",
-    version_base="1.1"
-)
+@hydra.main(config_path="conf/synthesis", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     global logger
     logger = getLogger(config.verbose)
@@ -206,8 +202,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/synthesis.py
+++ b/nnsvs/bin/synthesis.py
@@ -7,6 +7,10 @@ import numpy as np
 import torch
 from hydra.utils import to_absolute_path
 from nnmnkwii.io import hts
+from omegaconf import DictConfig, OmegaConf
+from scipy.io import wavfile
+from tqdm.auto import tqdm
+
 from nnsvs.gen import (
     postprocess_acoustic,
     postprocess_waveform,
@@ -16,9 +20,6 @@ from nnsvs.gen import (
 )
 from nnsvs.logger import getLogger
 from nnsvs.util import extract_static_scaler, init_seed, load_utt_list, load_vocoder
-from omegaconf import DictConfig, OmegaConf
-from scipy.io import wavfile
-from tqdm.auto import tqdm
 
 
 @hydra.main(config_path="conf/synthesis", config_name="config")
@@ -38,6 +39,7 @@ def my_app(config: DictConfig) -> None:
     checkpoint = torch.load(
         to_absolute_path(config.timelag.checkpoint),
         map_location=lambda storage, loc: storage,
+        weights_only=False,
     )
     timelag_model.load_state_dict(checkpoint["state_dict"])
     timelag_in_scaler = joblib.load(to_absolute_path(config.timelag.in_scaler_path))
@@ -50,6 +52,7 @@ def my_app(config: DictConfig) -> None:
     checkpoint = torch.load(
         to_absolute_path(config.duration.checkpoint),
         map_location=lambda storage, loc: storage,
+        weights_only=False,
     )
     duration_model.load_state_dict(checkpoint["state_dict"])
     duration_in_scaler = joblib.load(to_absolute_path(config.duration.in_scaler_path))
@@ -62,6 +65,7 @@ def my_app(config: DictConfig) -> None:
     checkpoint = torch.load(
         to_absolute_path(config.acoustic.checkpoint),
         map_location=lambda storage, loc: storage,
+        weights_only=False,
     )
     acoustic_model.load_state_dict(checkpoint["state_dict"])
     acoustic_in_scaler = joblib.load(to_absolute_path(config.acoustic.in_scaler_path))
@@ -84,7 +88,7 @@ def my_app(config: DictConfig) -> None:
         vocoder, vocoder_in_scaler, vocoder_config = None, None, None
         if config.synthesis.vocoder_type != "world":
             logger.warning("Vocoder checkpoint is not specified")
-            logger.info(f"Use world instead of {config.synthesis.vocoder_type}.")
+            logger.info("Use world instead of %s.", config.synthesis.vocoder_type)
         config.synthesis.vocoder_type = "world"
 
     # Run synthesis for each utt.

--- a/nnsvs/bin/train.py
+++ b/nnsvs/bin/train.py
@@ -168,7 +168,7 @@ def train_loop(
             return x
 
     else:
-        from tqdm import tqdm
+        from tqdm.auto import tqdm
 
     train_iter = 1
     for epoch in tqdm(range(1, config.train.nepochs + 1)):

--- a/nnsvs/bin/train.py
+++ b/nnsvs/bin/train.py
@@ -260,11 +260,7 @@ def train_loop(
     return last_dev_loss
 
 
-@hydra.main(
-    config_path="conf/train",
-    config_name="config",
-    version_base="1.1"
-)
+@hydra.main(config_path="conf/train", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     if "max_time_frames" in config.data and config.data.max_time_frames > 0:
         collate_fn = partial(
@@ -339,8 +335,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/train.py
+++ b/nnsvs/bin/train.py
@@ -261,7 +261,11 @@ def train_loop(
     return last_dev_loss
 
 
-@hydra.main(config_path="conf/train", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/train",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     if "max_time_frames" in config.data and config.data.max_time_frames > 0:
         collate_fn = partial(

--- a/nnsvs/bin/train.py
+++ b/nnsvs/bin/train.py
@@ -8,10 +8,6 @@ import torch
 import torch.distributed as dist
 from hydra.utils import to_absolute_path
 from nnmnkwii import metrics
-from omegaconf import DictConfig
-from torch import nn
-from torch.cuda.amp import autocast
-
 from nnsvs.base import PredictionType
 from nnsvs.mdn import mdn_get_most_probable_sigma_and_mu, mdn_loss
 from nnsvs.multistream import split_streams
@@ -25,6 +21,9 @@ from nnsvs.train_util import (
     setup,
 )
 from nnsvs.util import PyTorchStandardScaler, make_non_pad_mask
+from omegaconf import DictConfig
+from torch import nn
+from torch.cuda.amp import autocast
 
 
 @torch.no_grad()

--- a/nnsvs/bin/train.py
+++ b/nnsvs/bin/train.py
@@ -8,6 +8,10 @@ import torch
 import torch.distributed as dist
 from hydra.utils import to_absolute_path
 from nnmnkwii import metrics
+from omegaconf import DictConfig
+from torch import nn
+from torch.cuda.amp import autocast
+
 from nnsvs.base import PredictionType
 from nnsvs.mdn import mdn_get_most_probable_sigma_and_mu, mdn_loss
 from nnsvs.multistream import split_streams
@@ -21,9 +25,6 @@ from nnsvs.train_util import (
     setup,
 )
 from nnsvs.util import PyTorchStandardScaler, make_non_pad_mask
-from omegaconf import DictConfig
-from torch import nn
-from torch.cuda.amp import autocast
 
 
 @torch.no_grad()
@@ -260,7 +261,7 @@ def train_loop(
     return last_dev_loss
 
 
-@hydra.main(config_path="conf/train", config_name="config")
+@hydra.main(config_path="conf/train", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     if "max_time_frames" in config.data and config.data.max_time_frames > 0:
         collate_fn = partial(
@@ -335,8 +336,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter
 
 
 if __name__ == "__main__":
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter

--- a/nnsvs/bin/train_acoustic.py
+++ b/nnsvs/bin/train_acoustic.py
@@ -6,11 +6,6 @@ import mlflow
 import torch
 import torch.distributed as dist
 from hydra.utils import to_absolute_path
-from omegaconf import DictConfig
-from torch import nn
-from torch.cuda.amp import autocast
-from torch.nn.parallel import DistributedDataParallel as DDP
-
 from nnsvs.base import PredictionType
 from nnsvs.mdn import mdn_get_most_probable_sigma_and_mu, mdn_loss
 from nnsvs.multistream import split_streams
@@ -29,6 +24,10 @@ from nnsvs.train_util import (
     setup,
 )
 from nnsvs.util import PyTorchStandardScaler, make_non_pad_mask, make_pad_mask
+from omegaconf import DictConfig
+from torch import nn
+from torch.cuda.amp import autocast
+from torch.nn.parallel import DistributedDataParallel as DDP
 
 
 def train_step(

--- a/nnsvs/bin/train_acoustic.py
+++ b/nnsvs/bin/train_acoustic.py
@@ -458,7 +458,11 @@ def train_loop(
     return last_dev_loss
 
 
-@hydra.main(config_path="conf/train_acoustic", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/train_acoustic",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     if "max_time_frames" in config.data and config.data.max_time_frames > 0:
         collate_fn = partial(

--- a/nnsvs/bin/train_acoustic.py
+++ b/nnsvs/bin/train_acoustic.py
@@ -6,6 +6,11 @@ import mlflow
 import torch
 import torch.distributed as dist
 from hydra.utils import to_absolute_path
+from omegaconf import DictConfig
+from torch import nn
+from torch.cuda.amp import autocast
+from torch.nn.parallel import DistributedDataParallel as DDP
+
 from nnsvs.base import PredictionType
 from nnsvs.mdn import mdn_get_most_probable_sigma_and_mu, mdn_loss
 from nnsvs.multistream import split_streams
@@ -24,10 +29,6 @@ from nnsvs.train_util import (
     setup,
 )
 from nnsvs.util import PyTorchStandardScaler, make_non_pad_mask, make_pad_mask
-from omegaconf import DictConfig
-from torch import nn
-from torch.cuda.amp import autocast
-from torch.nn.parallel import DistributedDataParallel as DDP
 
 
 def train_step(
@@ -457,7 +458,7 @@ def train_loop(
     return last_dev_loss
 
 
-@hydra.main(config_path="conf/train_acoustic", config_name="config")
+@hydra.main(config_path="conf/train_acoustic", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     if "max_time_frames" in config.data and config.data.max_time_frames > 0:
         collate_fn = partial(
@@ -557,8 +558,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter
 
 
 if __name__ == "__main__":
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter

--- a/nnsvs/bin/train_acoustic.py
+++ b/nnsvs/bin/train_acoustic.py
@@ -457,11 +457,7 @@ def train_loop(
     return last_dev_loss
 
 
-@hydra.main(
-    config_path="conf/train_acoustic",
-    config_name="config",
-    version_base="1.1"
-)
+@hydra.main(config_path="conf/train_acoustic", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     if "max_time_frames" in config.data and config.data.max_time_frames > 0:
         collate_fn = partial(
@@ -561,8 +557,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/train_acoustic.py
+++ b/nnsvs/bin/train_acoustic.py
@@ -326,7 +326,7 @@ def train_loop(
             return x
 
     else:
-        from tqdm import tqdm
+        from tqdm.auto import tqdm
 
     train_iter = 1
     for epoch in tqdm(range(1, config.train.nepochs + 1)):

--- a/nnsvs/bin/train_postfilter.py
+++ b/nnsvs/bin/train_postfilter.py
@@ -7,11 +7,6 @@ import numpy as np
 import torch
 import torch.distributed as dist
 from hydra.utils import to_absolute_path
-from omegaconf import DictConfig
-from torch import nn
-from torch.cuda.amp import autocast
-from torch.nn import functional as F
-
 from nnsvs.multistream import select_streams
 from nnsvs.train_util import (
     collate_fn_default,
@@ -24,6 +19,10 @@ from nnsvs.train_util import (
     setup_gan,
 )
 from nnsvs.util import PyTorchStandardScaler, load_vocoder, make_non_pad_mask
+from omegaconf import DictConfig
+from torch import nn
+from torch.cuda.amp import autocast
+from torch.nn import functional as F
 
 
 def train_step(

--- a/nnsvs/bin/train_postfilter.py
+++ b/nnsvs/bin/train_postfilter.py
@@ -431,7 +431,11 @@ def train_loop(
     return last_dev_loss
 
 
-@hydra.main(config_path="conf/train_postfilter", config_name="config", version_base="1.1")
+@hydra.main(
+    config_path="conf/train_postfilter",
+    config_name="config",
+    version_base="1.1"
+)
 def my_app(config: DictConfig) -> None:
     # NOTE: set discriminator's in_dim automatically
     if config.model.netD.in_dim is None:

--- a/nnsvs/bin/train_postfilter.py
+++ b/nnsvs/bin/train_postfilter.py
@@ -283,7 +283,7 @@ def train_loop(
             return x
 
     else:
-        from tqdm import tqdm
+        from tqdm.auto import tqdm
 
     train_iter = 1
     for epoch in tqdm(range(1, config.train.nepochs + 1)):

--- a/nnsvs/bin/train_postfilter.py
+++ b/nnsvs/bin/train_postfilter.py
@@ -55,8 +55,8 @@ def train_step(
         # NOTE: Assuming 3rd stream is the V/UV
         vuv_idx = np.sum(model_config.stream_sizes[:2])
         is_v = torch.logical_and(
-            out_feats[:, :, vuv_idx: vuv_idx + 1] > 0,
-            in_feats[:, :, vuv_idx: vuv_idx + 1] > 0,
+            out_feats[:, :, vuv_idx : vuv_idx + 1] > 0,
+            in_feats[:, :, vuv_idx : vuv_idx + 1] > 0,
         )
         vuv = is_v
     else:
@@ -431,9 +431,7 @@ def train_loop(
 
 
 @hydra.main(
-    config_path="conf/train_postfilter",
-    config_name="config",
-    version_base="1.1"
+    config_path="conf/train_postfilter", config_name="config", version_base="1.1"
 )
 def my_app(config: DictConfig) -> None:
     # NOTE: set discriminator's in_dim automatically
@@ -535,8 +533,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()
 
 
 if __name__ == "__main__":
-    my_app()  # pylint: disable=no-value-for-parameter
+    my_app()

--- a/nnsvs/bin/train_postfilter.py
+++ b/nnsvs/bin/train_postfilter.py
@@ -7,6 +7,11 @@ import numpy as np
 import torch
 import torch.distributed as dist
 from hydra.utils import to_absolute_path
+from omegaconf import DictConfig
+from torch import nn
+from torch.cuda.amp import autocast
+from torch.nn import functional as F
+
 from nnsvs.multistream import select_streams
 from nnsvs.train_util import (
     collate_fn_default,
@@ -19,10 +24,6 @@ from nnsvs.train_util import (
     setup_gan,
 )
 from nnsvs.util import PyTorchStandardScaler, load_vocoder, make_non_pad_mask
-from omegaconf import DictConfig
-from torch import nn
-from torch.cuda.amp import autocast
-from torch.nn import functional as F
 
 
 def train_step(
@@ -55,8 +56,8 @@ def train_step(
         # NOTE: Assuming 3rd stream is the V/UV
         vuv_idx = np.sum(model_config.stream_sizes[:2])
         is_v = torch.logical_and(
-            out_feats[:, :, vuv_idx : vuv_idx + 1] > 0,
-            in_feats[:, :, vuv_idx : vuv_idx + 1] > 0,
+            out_feats[:, :, vuv_idx: vuv_idx + 1] > 0,
+            in_feats[:, :, vuv_idx: vuv_idx + 1] > 0,
         )
         vuv = is_v
     else:
@@ -430,7 +431,7 @@ def train_loop(
     return last_dev_loss
 
 
-@hydra.main(config_path="conf/train_postfilter", config_name="config")
+@hydra.main(config_path="conf/train_postfilter", config_name="config", version_base="1.1")
 def my_app(config: DictConfig) -> None:
     # NOTE: set discriminator's in_dim automatically
     if config.model.netD.in_dim is None:
@@ -531,8 +532,8 @@ def my_app(config: DictConfig) -> None:
 
 
 def entry():
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter
 
 
 if __name__ == "__main__":
-    my_app()
+    my_app()  # pylint: disable=no-value-for-parameter

--- a/nnsvs/diffsinger/diffusion.py
+++ b/nnsvs/diffsinger/diffusion.py
@@ -3,9 +3,8 @@ from functools import partial
 
 import numpy as np
 import torch
-from tqdm.auto import tqdm
-
 from nnsvs.base import BaseModel, PredictionType
+from tqdm.auto import tqdm
 
 
 def extract(a, t, x_shape):

--- a/nnsvs/diffsinger/diffusion.py
+++ b/nnsvs/diffsinger/diffusion.py
@@ -3,8 +3,9 @@ from functools import partial
 
 import numpy as np
 import torch
+from tqdm.auto import tqdm
+
 from nnsvs.base import BaseModel, PredictionType
-from tqdm import tqdm
 
 
 def extract(a, t, x_shape):

--- a/nnsvs/train_util.py
+++ b/nnsvs/train_util.py
@@ -198,9 +198,7 @@ def batch_by_size(
         sample_lens.append(num_tokens)
         sample_len = max(sample_len, num_tokens)
         assert sample_len <= max_tokens, (
-            "sentence at index {} of size {} exceeds max_tokens limit of {}!".format(
-                idx, sample_len, max_tokens
-            )
+            f"sentence at index {idx} of size {sample_len} exceeds max_tokens limit of {max_tokens}!"
         )
         num_tokens = (len(batch) + 1) * sample_len
 

--- a/nnsvs/train_util.py
+++ b/nnsvs/train_util.py
@@ -197,9 +197,7 @@ def batch_by_size(
         num_tokens = num_tokens_fn(idx)
         sample_lens.append(num_tokens)
         sample_len = max(sample_len, num_tokens)
-        assert (
-            sample_len <= max_tokens
-        ), (
+        assert sample_len <= max_tokens, (
             f"sentence at index {idx} of size {sample_len} exceeds"
             f"max_tokens limit of {max_tokens}!"
         )

--- a/nnsvs/train_util.py
+++ b/nnsvs/train_util.py
@@ -44,7 +44,7 @@ from torch.utils import data as data_utils
 from torch.utils.data.sampler import BatchSampler
 from torch.utils.tensorboard import SummaryWriter
 
-plt.style.use("seaborn-whitegrid")
+plt.style.use("seaborn-v0_8-whitegrid")
 
 
 class ShuffleBatchSampler(BatchSampler):
@@ -1055,8 +1055,8 @@ def compute_pitch_regularization_weight(segments, N, decay_size=25, max_w=0.5):
         L = e - s
         w[s:e] = max_w
         if L > decay_size * 2:
-            w[s : s + decay_size] *= torch.arange(decay_size) / decay_size
-            w[e - decay_size : e] *= torch.arange(decay_size - 1, -1, -1) / decay_size
+            w[s: s + decay_size] *= torch.arange(decay_size) / decay_size
+            w[e - decay_size: e] *= torch.arange(decay_size - 1, -1, -1) / decay_size
         else:
             # For shote notes (less than decay_size*0.01 sec) we don't use pitch regularization
             w[s:e] = 0.0

--- a/nnsvs/train_util.py
+++ b/nnsvs/train_util.py
@@ -197,10 +197,10 @@ def batch_by_size(
         num_tokens = num_tokens_fn(idx)
         sample_lens.append(num_tokens)
         sample_len = max(sample_len, num_tokens)
-        assert (
-            sample_len <= max_tokens
-        ), "sentence at index {} of size {} exceeds max_tokens " "limit of {}!".format(
-            idx, sample_len, max_tokens
+        assert sample_len <= max_tokens, (
+            "sentence at index {} of size {} exceeds max_tokens limit of {}!".format(
+                idx, sample_len, max_tokens
+            )
         )
         num_tokens = (len(batch) + 1) * sample_len
 
@@ -1055,8 +1055,8 @@ def compute_pitch_regularization_weight(segments, N, decay_size=25, max_w=0.5):
         L = e - s
         w[s:e] = max_w
         if L > decay_size * 2:
-            w[s: s + decay_size] *= torch.arange(decay_size) / decay_size
-            w[e - decay_size: e] *= torch.arange(decay_size - 1, -1, -1) / decay_size
+            w[s : s + decay_size] *= torch.arange(decay_size) / decay_size
+            w[e - decay_size : e] *= torch.arange(decay_size - 1, -1, -1) / decay_size
         else:
             # For shote notes (less than decay_size*0.01 sec) we don't use pitch regularization
             w[s:e] = 0.0
@@ -1727,7 +1727,7 @@ def eval_spss_model(
                 # (T, D_out) -> (T, static_dim)
                 pred_out_feats_denorm = multi_stream_mlpg(
                     pred_out_feats_denorm,
-                    (out_scaler.scale_ ** 2).cpu().numpy(),
+                    (out_scaler.scale_**2).cpu().numpy(),
                     get_windows(model_config.num_windows),
                     model_config.stream_sizes,
                     model_config.has_dynamic_features,

--- a/nnsvs/train_util.py
+++ b/nnsvs/train_util.py
@@ -197,8 +197,11 @@ def batch_by_size(
         num_tokens = num_tokens_fn(idx)
         sample_lens.append(num_tokens)
         sample_len = max(sample_len, num_tokens)
-        assert sample_len <= max_tokens, (
-            f"sentence at index {idx} of size {sample_len} exceeds max_tokens limit of {max_tokens}!"
+        assert (
+            sample_len <= max_tokens
+        ), (
+            f"sentence at index {idx} of size {sample_len} exceeds"
+            f"max_tokens limit of {max_tokens}!"
         )
         num_tokens = (len(batch) + 1) * sample_len
 
@@ -1725,7 +1728,7 @@ def eval_spss_model(
                 # (T, D_out) -> (T, static_dim)
                 pred_out_feats_denorm = multi_stream_mlpg(
                     pred_out_feats_denorm,
-                    (out_scaler.scale_**2).cpu().numpy(),
+                    (out_scaler.scale_ ** 2).cpu().numpy(),
                     get_windows(model_config.num_windows),
                     model_config.stream_sizes,
                     model_config.has_dynamic_features,

--- a/nnsvs/util.py
+++ b/nnsvs/util.py
@@ -9,11 +9,10 @@ import pkg_resources
 import pyworld
 import torch
 from hydra.utils import instantiate
-from omegaconf import OmegaConf
-from torch import nn
-
 from nnsvs.multistream import get_static_features, get_static_stream_sizes
 from nnsvs.usfgan import USFGANWrapper
+from omegaconf import OmegaConf
+from torch import nn
 
 try:
     from parallel_wavegan.utils import load_model

--- a/nnsvs/util.py
+++ b/nnsvs/util.py
@@ -9,10 +9,11 @@ import pkg_resources
 import pyworld
 import torch
 from hydra.utils import instantiate
-from nnsvs.multistream import get_static_features, get_static_stream_sizes
-from nnsvs.usfgan import USFGANWrapper
 from omegaconf import OmegaConf
 from torch import nn
+
+from nnsvs.multistream import get_static_features, get_static_stream_sizes
+from nnsvs.usfgan import USFGANWrapper
 
 try:
     from parallel_wavegan.utils import load_model


### PR DESCRIPTION
- For the Hydra>=1.2 compatibility, add main decorator `version_base="1.1"` in **nnsvs/bin/\*.py** .
- For the notebook compatibility, use `from tqdm.auto import tqdm` instead of `from tqdm import tqdm` in **nnsvs/bin/\*.py** .
- For the newer PyTorch compatibility, add `weights_only=False` option to `torch.load` calls in **gen_static_features.py** and **synthesis.py**.
- For the matplotlib>=3.6.0 compatibility, use `seaborn-v0_8-whitegrid` instead of `seaborn-whitegrid`  in **nnsvs/util.py** .

